### PR TITLE
Bend pulse and line glows around rounded-rect corners

### DIFF
--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamShaders.metal
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamShaders.metal
@@ -54,6 +54,49 @@ static float4 srcOver(float4 src, float4 dst) {
     return src + dst * (1.0 - src.a);
 }
 
+// Arc-length parametrization of a rounded-rect border. Returns
+// float3(s, d, P): s = clockwise arc length from the top-center, d = distance
+// inside the border (negative outside), P = total perimeter. Inside the
+// rect's interior "cross" (far from every edge) s snaps to the nearest edge's
+// projection; callers only evaluate border-hugging fields there, so the far
+// interior never becomes visible.
+static float3 borderPathCoord(float2 rel, float2 halfSize, float r) {
+    float ex = max(halfSize.x - r, 0.0);
+    float ey = max(halfSize.y - r, 0.0);
+    float arc = 0.5 * M_PI_F * r;
+    float P = 4.0 * ex + 4.0 * ey + 4.0 * arc;
+    float halfPi = 0.5 * M_PI_F;
+    float x = rel.x, y = rel.y;
+    float ax = fabs(x), ay = fabs(y);
+
+    if (ax > ex && ay > ey) {
+        // Corner arc region: measure the angle around the arc center.
+        float2 k = float2(copysign(ex, x), copysign(ey, y));
+        float2 v = rel - k;
+        float d = r - length(v);
+        float a, base;
+        if (x >= 0.0 && y < 0.0)  { a = atan2(v.x, -v.y);  base = ex; }
+        else if (x >= 0.0)        { a = atan2(v.y, v.x);   base = ex + arc + 2.0 * ey; }
+        else if (y >= 0.0)        { a = atan2(-v.x, v.y);  base = 3.0 * ex + 2.0 * arc + 2.0 * ey; }
+        else                      { a = atan2(-v.y, -v.x); base = 3.0 * ex + 3.0 * arc + 4.0 * ey; }
+        return float3(base + r * clamp(a, 0.0, halfPi), d, P);
+    }
+
+    bool vertBand;
+    if (ax > ex)      vertBand = true;
+    else if (ay > ey) vertBand = false;
+    else              vertBand = (halfSize.x - ax) < (halfSize.y - ay);
+
+    if (vertBand) {
+        if (x >= 0.0) return float3(ex + arc + (y + ey), halfSize.x - x, P);
+        return float3(3.0 * ex + 3.0 * arc + 2.0 * ey + (ey - y), x + halfSize.x, P);
+    }
+    if (y < 0.0) {
+        return float3((x >= 0.0) ? x : P + x, y + halfSize.y, P);
+    }
+    return float3(ex + 2.0 * arc + 2.0 * ey + (ex - x), halfSize.y - y, P);
+}
+
 // ── Rotate-family layer ──────────────────────────────────────────────────────
 //
 // layerKind: 0 = stroke ring (::after), 1 = inner glow (::before),
@@ -206,6 +249,7 @@ static float stopAlpha(float t, float a0, float p1, float a1, float p2, float a2
     float borderWidth,
     float geomKind,
     float edgeMaskPx,
+    float wrapCorners,
     device const float *radial, int radialCount,
     device const float *blobs, int blobCount,
     device const float *cm, int cmCount,
@@ -214,6 +258,7 @@ static float stopAlpha(float t, float a0, float p1, float a1, float p2, float a2
     float2 rectCenter = rectOrigin + rectSize * 0.5;
     float2 rel = position - rectCenter;
     int kind = int(geomKind);
+    bool wrap = wrapCorners > 0.5;
 
     // Geometry mask.
     float geom = 1.0;
@@ -232,14 +277,27 @@ static float stopAlpha(float t, float a0, float p1, float a1, float p2, float a2
         if (geom <= 0.0) return half4(0.0);
     }
 
+    // Border-path coordinates of this pixel (wrap mode only): x = clockwise
+    // arc length along the border, y = distance inside it, z = perimeter.
+    float3 pathP = float3(0.0);
+    if (wrap) {
+        pathP = borderPathCoord(rel, rectSize * 0.5, radius);
+    }
+
     float mask = 1.0;
 
-    // Edge fade (rounded-rect fill only).
+    // Edge fade (rounded-rect fill only). In wrap mode the fade follows the
+    // border's inside distance, so its isolines bend around the corner arcs
+    // instead of forming the square union of two straight gradients.
     if (kind == 1 && edgeMaskPx > 0.0) {
-        float2 lp = position - rectOrigin;
-        float ev = max(1.0 - lp.y / edgeMaskPx, 1.0 - (rectSize.y - lp.y) / edgeMaskPx);
-        float eh = max(1.0 - lp.x / edgeMaskPx, 1.0 - (rectSize.x - lp.x) / edgeMaskPx);
-        mask *= clamp(max(ev, 0.0) + max(eh, 0.0), 0.0, 1.0);
+        if (wrap) {
+            mask *= clamp(1.0 - pathP.y / edgeMaskPx, 0.0, 1.0);
+        } else {
+            float2 lp = position - rectOrigin;
+            float ev = max(1.0 - lp.y / edgeMaskPx, 1.0 - (rectSize.y - lp.y) / edgeMaskPx);
+            float eh = max(1.0 - lp.x / edgeMaskPx, 1.0 - (rectSize.x - lp.x) / edgeMaskPx);
+            mask *= clamp(max(ev, 0.0) + max(eh, 0.0), 0.0, 1.0);
+        }
     }
 
     // Radial window mask (line family).
@@ -261,6 +319,14 @@ static float stopAlpha(float t, float a0, float p1, float a1, float p2, float a2
     if (mask <= 0.001) return half4(0.0);
 
     // Blob stack: premultiplied source-over, FIRST blob on top.
+    //
+    // Wrap mode (pulse-inner glow): blobs are evaluated in border-path space —
+    // tangential distance measured along the border (through the corner arcs)
+    // and normal distance measured inward — so the glow bends with the corner
+    // radius and neighbouring edge blobs blend along the path instead of
+    // overlapping as straight-edged ellipses. Along straight edges this is
+    // identical to the planar evaluation. e[13] carries the blob's tangential
+    // axis (1 = the blob hugs a left/right edge, its ry runs along the border).
     float4 acc = float4(0.0);
     int nBlobs = blobCount / 14;
     for (int i = nBlobs - 1; i >= 0; i--) {
@@ -268,7 +334,19 @@ static float stopAlpha(float t, float a0, float p1, float a1, float p2, float a2
         float rx = max(e[0], 0.001);
         float ry = max(e[1], 0.001);
         float2 c = float2(e[2], e[3]);
-        float t = length((position - c) / float2(rx, ry));
+        float t;
+        if (wrap) {
+            float3 pathC = borderPathCoord(c - rectCenter, rectSize * 0.5, radius);
+            float ds = pathP.x - pathC.x;
+            ds -= pathP.z * rint(ds / max(pathP.z, 0.0001));
+            float dd = pathP.y - pathC.y;
+            bool vertical = e[13] > 0.5;
+            float rT = vertical ? ry : rx;
+            float rN = vertical ? rx : ry;
+            t = length(float2(ds / rT, dd / rN));
+        } else {
+            t = length((position - c) / float2(rx, ry));
+        }
         float alpha = stopAlpha(t, e[7], e[8], e[9], e[10], e[11], e[12]);
         if (alpha <= 0.0) continue;
         acc = srcOver(float4(float3(e[4], e[5], e[6]) * alpha, alpha), acc);

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamTuning.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamTuning.swift
@@ -41,6 +41,13 @@ public struct BeamTuning: Equatable, Sendable {
     public var glowBrightness: Double?
     public var glowSaturate: Double?
 
+    /// Multiplier on the size of `pulse-inner`'s inward glow blobs (the z1
+    /// layer, including the corner accents). 1 keeps the spec sizes. Values
+    /// below 1 pull the inner wash tighter to the border so it hugs corners
+    /// the way the rotate family's (0.9x-derived) inner glow does. iOS-only
+    /// tuning hook — the web library has no equivalent custom property yet.
+    public var innerSizeScale: Double
+
     public init(
         glowBoost: Double = 1,
         strokeOpacity: Double = 1,
@@ -49,7 +56,8 @@ public struct BeamTuning: Equatable, Sendable {
         coreBlur: Double? = nil,
         bloomBlur: Double? = nil,
         glowBrightness: Double? = nil,
-        glowSaturate: Double? = nil
+        glowSaturate: Double? = nil,
+        innerSizeScale: Double = 1
     ) {
         self.glowBoost = glowBoost
         self.strokeOpacity = strokeOpacity
@@ -59,6 +67,7 @@ public struct BeamTuning: Equatable, Sendable {
         self.bloomBlur = bloomBlur
         self.glowBrightness = glowBrightness
         self.glowSaturate = glowSaturate
+        self.innerSizeScale = innerSizeScale
     }
 
     /// Library defaults — no tuning applied.

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/LineBeamLayers.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/LineBeamLayers.swift
@@ -178,6 +178,12 @@ struct LineBeamLayers: View {
             .float(config.sizeConfig.borderWidth),
             .float(geomKind),
             .float(edgeMaskPx),
+            // Corner-wrap: the line family's blobs all anchor to the bottom
+            // border, so evaluating them in border-path space bends the
+            // traveling streak around the corner radius as it reaches the
+            // ends. Identical along the straight bottom edge; iOS deviation
+            // from the web renderer (see the pulse-inner layer note).
+            .float(1),
             .floatArray(radial),
             .floatArray(blobs),
             .floatArray(matrix),

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/PulseBeamLayers.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/PulseBeamLayers.swift
@@ -167,12 +167,20 @@ struct PulseBeamLayers: View {
             // (web withAlphaVar); static corner accents multiply their base.
             let alpha = d.region == 0 ? d.color.a * bop : bop
             let end = d.fadeEnd
+            // Which border edge the blob hugs, for the shader's corner-wrap
+            // evaluation: 1 when it sits against a left/right edge (its height
+            // runs along the border), 0 for top/bottom. Ignored outside wrap
+            // mode (the reserved 14th float was always 0 before).
+            let edgeDistX = max(min(d.xFrac, 1 - d.xFrac) * boxSize.width, 0)
+            let edgeDistY = max(min(d.yFrac, 1 - d.yFrac) * boxSize.height, 0)
+            let vertical: Float = edgeDistX < edgeDistY ? 1 : 0
             out += [
                 Float(d.w * bw * sx), Float(d.h * bh * sy),
                 Float(boxOrigin.x + d.xFrac * boxSize.width + dx),
                 Float(boxOrigin.y + d.yFrac * boxSize.height + dy),
                 Float(d.color.r), Float(d.color.g), Float(d.color.b), Float(alpha),
-                Float(end / 3), Float(alpha * 2 / 3), Float(2 * end / 3), Float(alpha / 3), Float(end), 0,
+                Float(end / 3), Float(alpha * 2 / 3), Float(2 * end / 3), Float(alpha / 3), Float(end),
+                vertical,
             ]
         }
         return out
@@ -281,7 +289,16 @@ struct PulseBeamLayers: View {
                     boxPad: 0, elementSize: elementSize,
                     radius: config.radius, borderWidth: config.sizeConfig.borderWidth,
                     geomKind: 1, edgeMaskPx: spec.rotate.innerEdgeMaskPx,
-                    blobs: liveBlobs(innerDefs(), osc: osc, boxOrigin: .zero, boxSize: elementSize, sx: 1, sy: 1),
+                    // Corner-wrap: evaluate the glow in border-path space so it
+                    // bends with the corner radius instead of straight-edged
+                    // ellipses clashing where two edges meet. iOS-only
+                    // deviation from the web renderer (which shows the same
+                    // artifact); keep the SkSL twin in sync when porting.
+                    wrapCorners: 1,
+                    blobs: liveBlobs(
+                        innerDefs(), osc: osc, boxOrigin: .zero, boxSize: elementSize,
+                        sx: tuning.innerSizeScale, sy: tuning.innerSizeScale
+                    ),
                     matrix: cm,
                     opacity: base * config.themeConfig.innerOpacity * tuning.innerOpacity
                 )
@@ -317,6 +334,7 @@ struct PulseBeamLayers: View {
         borderWidth: Double,
         geomKind: Double,
         edgeMaskPx: Double,
+        wrapCorners: Double = 0,
         blobs: [Float],
         matrix: [Float],
         opacity: Double
@@ -332,6 +350,7 @@ struct PulseBeamLayers: View {
             .float(borderWidth),
             .float(geomKind),
             .float(edgeMaskPx),
+            .float(wrapCorners),
             .floatArray(BlobEncoder.noRadial),
             .floatArray(blobs),
             .floatArray(matrix),

--- a/ports/ios/BorderBeamShowcase/Sources/ShowcaseView.swift
+++ b/ports/ios/BorderBeamShowcase/Sources/ShowcaseView.swift
@@ -7,23 +7,65 @@ import BorderBeamKit
 /// beam around the physical screen edge, gradient-masked so only the lower
 /// portion shows.
 struct ShowcaseView: View {
-    @State private var page = 0
+    // Paged with the iOS 17 ScrollView APIs rather than TabView(.page): the
+    // page-style TabView can snap back to its first page on transient
+    // re-layouts, while scrollPosition survives them.
+    // `-initialPage N` on the launch arguments opens a specific page, so a
+    // single beam type can be inspected without swiping there by hand.
+    @State private var page: Int? = 0
+    /// True from the moment a swipe starts until the pager settles; the
+    /// current page's effect fades out (300ms) while this is set.
+    @State private var isSwiping = false
+
+    private var current: Int { page ?? 0 }
+
+    private func effectVisible(_ index: Int) -> Bool {
+        current == index && !isSwiping
+    }
 
     var body: some View {
         GeometryReader { geo in
             ZStack {
                 Showcase.background.ignoresSafeArea()
 
-                TabView(selection: $page) {
-                    EdgeBeamPage(size: .pulseInner, subtitle: "Pulse").tag(0)
-                    EdgeBeamPage(size: .line, subtitle: "Line").tag(1)
-                    ButtonPage().tag(2)
-                    EdgeBeamPage(size: .md, subtitle: "Rotate").tag(3)
+                ScrollView(.horizontal) {
+                    LazyHStack(spacing: 0) {
+                        Group {
+                            EdgeBeamPage(size: .md, subtitle: "Rotate", active: effectVisible(0)).id(0)
+                            EdgeBeamPage(size: .pulseInner, subtitle: "Pulse", active: effectVisible(1)).id(1)
+                            ButtonPage(active: effectVisible(2)).id(2)
+                            EdgeBeamPage(size: .line, subtitle: "Line", active: effectVisible(3)).id(3)
+                        }
+                        .containerRelativeFrame(.horizontal)
+                    }
+                    .scrollTargetLayout()
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
+                .scrollTargetBehavior(.paging)
+                .scrollPosition(id: $page)
+                .scrollIndicators(.hidden)
                 .ignoresSafeArea()
+                // Fade the current effect out the moment a swipe starts; the
+                // incoming effect fades back in when the pager settles (or the
+                // swipe is cancelled and springs back).
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 10)
+                        .onChanged { _ in isSwiping = true }
+                        .onEnded { _ in
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                isSwiping = false
+                            }
+                        }
+                )
+                .onChange(of: page) { _, _ in isSwiping = false }
+                // Seeding `page` before first layout leaves the ScrollView at
+                // page 0, so the jump has to happen once the content exists.
+                .onAppear {
+                    let target = UserDefaults.standard.integer(forKey: "initialPage")
+                    guard target != 0 else { return }
+                    DispatchQueue.main.async { page = target }
+                }
 
-                PageDots(count: 4, current: page)
+                PageDots(count: 4, current: current)
                     .position(x: geo.size.width / 2, y: geo.size.height * Showcase.dotsY)
             }
         }
@@ -35,17 +77,46 @@ struct ShowcaseView: View {
 /// Layout constants lifted from the Figma frames (402x874, iPhone 16/17 Pro).
 private enum Showcase {
     static let background = Color(red: 0x07 / 255, green: 0x07 / 255, blue: 0x07 / 255)
-    /// Corner radius of the device-frame rounded rect the beams hug.
-    static let screenCornerRadius: Double = 56
+    /// Corner radius the beams hug. The Figma frame rounds at 56, but the
+    /// iPhone 16 Pro's physical display corner radius is 62pt — the hairline
+    /// stroke visibly cuts the corner unless it matches the real curve.
+    static let screenCornerRadius: Double = 62
     /// Label block center: y 597 + half of the 51pt text block, over 874.
     static let labelY: CGFloat = 622.5 / 874
-    /// Height of the bottom-anchored box the edge beams wrap, as a fraction of
-    /// the screen. The beam palette positions its color blobs at fractions of
-    /// the wrapped element with card-scale pixel sizes, so wrapping the whole
-    /// screen leaves most of the border unlit (and puts the right-edge blobs
-    /// up in the faded-out zone). A shorter box keeps the visible U — left,
-    /// bottom, right — fully covered.
-    static let beamBoxHeight: CGFloat = 0.45
+    /// Height of the bottom-anchored box the pulse/rotate beams wrap, as a
+    /// fraction of the screen (the region marked in the design feedback:
+    /// from just above the title block down to the bottom edge).
+    static let pulseRotateBoxHeight: CGFloat = 0.45
+    /// The beam palette sizes its color blobs in card-scale pixels, so drawing
+    /// straight onto the screen-sized box leaves most of the border unlit.
+    /// Instead the pulse/rotate beams render on a canvas this many times
+    /// smaller — card-like, where the blobs nearly close the ring — and the
+    /// whole rendering is scaled up to fill the box, keeping the ring
+    /// visually continuous like the web demo card. Rotate's glows sit further
+    /// apart in the palette, so it gets a stronger condensing scale.
+    static let pulseBeamScale: CGFloat = 2.0
+    static let rotateBeamScale: CGFloat = 2.6
+    /// Per-type beam durations. Pulse keeps the spec default (2.3s) with the
+    /// mirrored copy desynced; rotate runs 30% slower than its 1.96s spec
+    /// default, again with the mirrored copy off-phase.
+    static func beamDuration(for size: BeamSize, mirrored: Bool) -> Double? {
+        switch size {
+        case .md: return mirrored ? 3.6 : 2.8
+        case .pulseInner: return mirrored ? 2.9 : nil
+        default: return nil
+        }
+    }
+    /// Rotate's hue ping-pong stays within ±30° by default, which reads as a
+    /// narrow slice of the colorful palette; widening it sweeps the full
+    /// spectrum over the 12s hue period.
+    static let rotateHueRange: Double = 120
+    /// The line beam anchors everything to the box's bottom edge, so it can
+    /// afford a taller box; its whole effect is scaled up 40% instead.
+    static let lineBoxHeight: CGFloat = 0.45
+    static let lineScale: CGFloat = 1.8
+    /// Swipe transition: the outgoing effect fades out over this duration the
+    /// moment the drag starts; the incoming one fades in when the pager lands.
+    static let effectFadeSeconds: Double = 0.3
     /// Dot row center: y 684 + 4, over 874.
     static let dotsY: CGFloat = 688 / 874
     /// Pill center: y 772 + 26, over 874 — kept as a distance from the bottom
@@ -57,22 +128,45 @@ private enum Showcase {
 private struct EdgeBeamPage: View {
     let size: BeamSize
     let subtitle: String
+    /// False while the page is off-screen or a swipe is in flight; drives the
+    /// 300ms fade of the beam stack (the label stays put).
+    let active: Bool
+
+    private var isLine: Bool { size == .line }
+    private var boxHeight: CGFloat {
+        isLine ? Showcase.lineBoxHeight : Showcase.pulseRotateBoxHeight
+    }
+    /// Every beam draws on a shrunken canvas and is scaled back up to the box,
+    /// which both enlarges the effect and — because the canvas radius is the
+    /// screen radius divided by the same factor — lands the canvas corners
+    /// exactly on the phone's corners, so the wrapped glow follows them.
+    private var renderScale: CGFloat {
+        if isLine { return Showcase.lineScale }
+        return size == .md ? Showcase.rotateBeamScale : Showcase.pulseBeamScale
+    }
+    private var canvasShrink: CGFloat { renderScale }
 
     var body: some View {
         GeometryReader { geo in
             ZStack {
-                BorderBeam(
-                    size: size,
-                    colorVariant: .colorful,
-                    theme: .dark,
-                    borderRadius: Showcase.screenCornerRadius,
-                    tuning: size.isPulse ? .showcasePulse : .none
-                ) {
-                    Color.clear
+                Group {
+                    beamLayer(in: geo.size, mirrored: false)
+                    // Second, horizontally mirrored and desynced instance:
+                    // the palette's blob positions land in the gaps their
+                    // originals leave, doubling the visible glows (and giving
+                    // rotate two counter-sweeping arcs).
+                    if !isLine {
+                        beamLayer(in: geo.size, mirrored: true)
+                    }
                 }
-                .mask(bottomFade)
-                .frame(height: geo.size.height * Showcase.beamBoxHeight)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                // The web demo card clips its beam with `overflow: hidden`;
+                // without the equivalent here the corner glow spills past the
+                // display's rounded corners and reads as a square edge.
+                // Circular style matches the shader ring's geometry, so the
+                // clip never shaves the hairline stroke at the corners.
+                .clipShape(RoundedRectangle(cornerRadius: Showcase.screenCornerRadius))
+                .opacity(active ? 1 : 0)
+                .animation(.easeInOut(duration: Showcase.effectFadeSeconds), value: active)
 
                 PageLabel(subtitle: subtitle)
                     .position(x: geo.size.width / 2, y: geo.size.height * Showcase.labelY)
@@ -81,14 +175,44 @@ private struct EdgeBeamPage: View {
         .ignoresSafeArea()
     }
 
+    private func beamLayer(in screen: CGSize, mirrored: Bool) -> some View {
+        BorderBeam(
+            size: size,
+            colorVariant: .colorful,
+            theme: .dark,
+            // Desync the mirrored copy so the two breathe/sweep out of phase.
+            duration: Showcase.beamDuration(for: size, mirrored: mirrored),
+            borderRadius: Showcase.screenCornerRadius / canvasShrink,
+            // The rotate arc reads faint at screen-edge scale; lift it
+            // the same way the pulse pages are lifted by their tuning.
+            brightness: size == .md ? 1.5 : nil,
+            saturation: size == .md ? 1.35 : nil,
+            hueRange: size == .md ? Showcase.rotateHueRange : 30,
+            tuning: size.isPulse ? .showcasePulse : .none
+        ) {
+            Color.clear
+        }
+        .mask(bottomFade)
+        .frame(
+            width: screen.width / canvasShrink,
+            height: screen.height * boxHeight / canvasShrink
+        )
+        .scaleEffect(
+            x: mirrored ? -renderScale : renderScale,
+            y: renderScale,
+            anchor: .bottom
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+    }
+
     /// Fades the top of the beam box to nothing, hiding its top edge so the
     /// beam reads as emerging from the bottom of the screen.
     private var bottomFade: LinearGradient {
         LinearGradient(
             stops: [
                 .init(color: .clear, location: 0),
-                .init(color: .clear, location: 0.12),
-                .init(color: .white, location: 0.55),
+                .init(color: .clear, location: 0.08),
+                .init(color: .white, location: isLine ? 0.55 : 0.38),
             ],
             startPoint: .top,
             endPoint: .bottom
@@ -98,13 +222,15 @@ private struct EdgeBeamPage: View {
 
 /// "Search or ask" pill with a pulse-outside beam, anchored near the bottom.
 private struct ButtonPage: View {
+    let active: Bool
+
     var body: some View {
         GeometryReader { geo in
             ZStack {
                 PageLabel(subtitle: "Button")
                     .position(x: geo.size.width / 2, y: geo.size.height * Showcase.labelY)
 
-                SearchPill()
+                SearchPill(active: active)
                     .position(
                         x: geo.size.width / 2,
                         y: geo.size.height - Showcase.pillBottomOffset
@@ -116,33 +242,42 @@ private struct ButtonPage: View {
 }
 
 private struct SearchPill: View {
+    /// Fades only the beam (300ms, in sync with the edge pages); the pill
+    /// itself stays visible like the page labels do.
+    let active: Bool
+
     private let radius: Double = 26
 
     var body: some View {
-        BorderBeam(
-            size: .pulseInner,
-            colorVariant: .colorful,
-            theme: .dark,
-            borderRadius: radius
-        ) {
-            RoundedRectangle(cornerRadius: radius)
-                .fill(Color(red: 0x1D / 255, green: 0x1D / 255, blue: 0x1D / 255))
-                .overlay(
-                    RoundedRectangle(cornerRadius: radius)
-                        .strokeBorder(
-                            Color(red: 44 / 255, green: 47 / 255, blue: 54 / 255)
-                                .opacity(0.52),
-                            lineWidth: 1.26
-                        )
-                )
-                .overlay(alignment: .leading) {
-                    Text("Search or ask")
-                        .font(.system(size: 19))
-                        .foregroundStyle(Color(white: 0x55 / 255))
-                        .padding(.leading, 21)
+        RoundedRectangle(cornerRadius: radius)
+            .fill(Color(red: 0x1D / 255, green: 0x1D / 255, blue: 0x1D / 255))
+            .overlay(
+                RoundedRectangle(cornerRadius: radius)
+                    .strokeBorder(
+                        Color(red: 44 / 255, green: 47 / 255, blue: 54 / 255)
+                            .opacity(0.52),
+                        lineWidth: 1.26
+                    )
+            )
+            .overlay(alignment: .leading) {
+                Text("Search or ask")
+                    .font(.system(size: 19))
+                    .foregroundStyle(Color(white: 0x55 / 255))
+                    .padding(.leading, 21)
+            }
+            .frame(width: 302, height: 52)
+            .overlay {
+                BorderBeam(
+                    size: .pulseInner,
+                    colorVariant: .colorful,
+                    theme: .dark,
+                    borderRadius: radius
+                ) {
+                    Color.clear
                 }
-                .frame(width: 302, height: 52)
-        }
+                .opacity(active ? 1 : 0)
+                .animation(.easeInOut(duration: Showcase.effectFadeSeconds), value: active)
+            }
     }
 }
 
@@ -178,15 +313,17 @@ private struct PageDots: View {
 }
 
 extension BeamTuning {
-    /// The web demo's tuned pulse preset (see `--pulse-glow-boost` and friends
-    /// in demo/src/styles.css): 1.71x layer opacity with matching glow
-    /// brightness/saturation, so the pulse reads as vividly as the web demo
-    /// instead of the softer library defaults.
+    /// Derived from the web demo's tuned pulse preset (`--pulse-glow-boost`
+    /// and friends in demo/src/styles.css) but with the opacity multipliers
+    /// pushed further: the per-quadrant breathing oscillators dip close to
+    /// zero, and on a screen-edge beam that read as "the glow disappeared".
+    /// The higher floor keeps every quadrant visible through its dim phase
+    /// (peaks clamp at 1, exactly like CSS opacity).
     static let showcasePulse = BeamTuning(
         glowBoost: 1.05,
-        strokeOpacity: 1.71,
-        innerOpacity: 1.71,
-        bloomOpacity: 1.71,
+        strokeOpacity: 2.4,
+        innerOpacity: 2.4,
+        bloomOpacity: 2.4,
         glowBrightness: 1.3 * 1.71,
         glowSaturate: 1.2 * 1.71
     )
@@ -194,4 +331,9 @@ extension BeamTuning {
 
 #Preview {
     ShowcaseView()
+}
+
+#Preview("Pulse page") {
+    EdgeBeamPage(size: .pulseInner, subtitle: "Pulse", active: true)
+        .background(Showcase.background)
 }


### PR DESCRIPTION
The blob shader evaluated every glow in planar space, so blobs anchored to different edges ended in straight elliptical edges that clashed where two edges met, and a glow crossing a corner cut across the arc instead of following it. Screen-sized elements make this obvious: the showcase's edge beams hug the display's 62pt corner radius.

Add a `wrapCorners` mode to `beamBlobLayer` that evaluates blobs in border-path space — arc length along the rounded-rect border crossed with distance inward — so a glow bends with the corner radius and neighbouring blobs blend along the path. Along straight edges the math reduces to the previous planar evaluation, so the look elsewhere is unchanged. The blob record's reserved 14th float now carries which edge a blob hugs, which picks its tangential radius; `borderPathCoord` supplies the mapping.

Enabled for pulse-inner's glow layer and the line family (whose blobs all anchor to the bottom border). The ring, bloom and rotate layers keep planar evaluation.

This deviates from the web renderer and the SkSL twin, which still show the artifact; port `blobShader.ts` to match when convenient.

Showcase: render every edge beam on a shrunken canvas whose radius is the screen radius over the same factor, so scaling back up lands the canvas corners on the phone's corners; page order is now Rotate, Pulse, Button, Line; effects cross-fade over 300ms on swipe; `-initialPage N` opens a given page for inspection.

Also add `BeamTuning.innerSizeScale` for scaling pulse-inner's glow blobs (default 1 — no change unless a consumer opts in).