### PR TITLE
Add custom brand colors via ordered `colors` prop (web + SwiftUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.0
+
+### Added
+- `colors` prop (web) and `colors:` parameter (BorderBeamKit) for custom brand palettes ([#4](https://github.com/Jakubantalik/border-beam/issues/4)). Pass an ordered list of colors; they cycle through the default palette's gradient stops while all hand-tuned geometry and per-stop alphas are preserved. Takes precedence over `colorVariant` and always renders with static colors so brand hues stay exact.
+- `customColors` section in `beam-spec.json` documenting the shared derivation rules (reference variant, forced static colors, line-bloom recolor map) so ports stay in sync.
+
 ## 1.1.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -86,6 +86,35 @@ Four color palettes are available:
 
 All variants except `mono` animate through a hue-shift cycle.
 
+## Custom colors
+
+Match the beam to your brand with an ordered list of colors:
+
+```tsx
+<BorderBeam colors={['#e63946', '#457b9d', '#2a9d8f']}>
+  <Card />
+</BorderBeam>
+```
+
+- Accepts hex (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) and `rgb()` / `rgba()`
+  with number or percentage channels. Alpha is ignored — the beam layers manage
+  their own opacity. Entries that fail to parse are skipped; if nothing parses,
+  `colorVariant` applies.
+- Colors cycle **in order** through the palette's gradient stops, so the first
+  color is the most prominent; a single color gives a monochrome brand beam.
+- All of the hand-tuned geometry (positions, sizes, per-stop alphas) of the
+  default palette is preserved — only the colors are swapped.
+- `colors` takes precedence over `colorVariant` and always renders with static
+  colors (like `mono`) so brand hues stay exact.
+- The same colors are used for both themes; `theme` still adapts the layer
+  opacities and saturation.
+
+Also available in the SwiftUI port:
+
+```swift
+Card().borderBeam(.md, colors: [.purple, .pink])
+```
+
 ## Theme
 
 Adapts beam colors for dark or light backgrounds:
@@ -127,6 +156,7 @@ const [active, setActive] = useState(true);
 | `children` | `ReactNode` | — | Content to wrap |
 | `size` | `'sm' \| 'md' \| 'line' \| 'pulse-outside' \| 'pulse-inner'` | `'md'` | Size/type preset |
 | `colorVariant` | `'colorful' \| 'mono' \| 'ocean' \| 'sunset'` | `'colorful'` | Color palette |
+| `colors` | `string[]` | — | Custom colors in display order; overrides `colorVariant`, always static |
 | `theme` | `'dark' \| 'light' \| 'auto'` | `'dark'` | Background adaptation |
 | `strength` | `number` | `1` | Effect opacity (0–1), only affects the beam layers |
 | `duration` | `number` | `1.96` / `3.1` / `2.3` | Animation cycle duration in seconds (rotate / line / pulse) |

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -327,12 +327,20 @@ const INSTALL_NOTE_BY_PLATFORM: Record<Platform, string | null> = {
   native: 'In beta \u2014 not yet published. Copy ports/react-native/border-beam-native from the repo, then install the two peer dependencies above.',
 };
 
-const COLOR_OPTIONS: { value: BorderBeamColorVariant; label: string }[] = [
+/** The four library variants plus "Custom", which drives the `colors` prop
+    with a user-editable ordered palette instead of a preset. */
+type PlaygroundColor = BorderBeamColorVariant | 'custom';
+
+const COLOR_OPTIONS: { value: PlaygroundColor; label: string }[] = [
   { value: 'colorful', label: 'Colorful' },
   { value: 'mono', label: 'Mono' },
   { value: 'ocean', label: 'Ocean' },
   { value: 'sunset', label: 'Sunset' },
+  { value: 'custom', label: 'Custom' },
 ];
+
+/** Seed palette for Custom — ordered; the first color is the most prominent. */
+const DEFAULT_CUSTOM_COLORS = ['#e63946', '#457b9d', '#2a9d8f'];
 
 export default function App() {
   const [family, setFamily] = useState<BeamFamily>(() => familyFromPath(window.location.pathname));
@@ -340,7 +348,8 @@ export default function App() {
   const [playgroundSize, setPlaygroundSize] = useState<BorderBeamSize>(
     () => DEFAULT_SIZE_BY_FAMILY[familyFromPath(window.location.pathname)]
   );
-  const [playgroundColorVariant, setPlaygroundColorVariant] = useState<BorderBeamColorVariant>('colorful');
+  const [playgroundColorVariant, setPlaygroundColorVariant] = useState<PlaygroundColor>('colorful');
+  const [playgroundCustomColors, setPlaygroundCustomColors] = useState<string[]>(DEFAULT_CUSTOM_COLORS);
   const [playgroundStrength, setPlaygroundStrength] = useState(70);
   const [platform, setPlatform] = useState<Platform>('react');
   const [theme, setTheme] = useState<ThemeMode>(getInitialTheme);
@@ -420,7 +429,12 @@ export default function App() {
   const installCmd = INSTALL_BY_PLATFORM[platform];
   const usageCode = USAGE_BY_PLATFORM[platform];
   const installNote = INSTALL_NOTE_BY_PLATFORM[platform];
-  const playgroundCode = `<BorderBeam size="${playgroundSize}" colorVariant="${playgroundColorVariant}"${playgroundStrength < 100 ? ` strength={${playgroundStrength / 100}}` : ''}>
+  const isCustomColor = playgroundColorVariant === 'custom';
+  const playgroundVariant: BorderBeamColorVariant = isCustomColor ? 'colorful' : playgroundColorVariant;
+  const playgroundColorProp = isCustomColor
+    ? ` colors={[${playgroundCustomColors.map((c) => `'${c}'`).join(', ')}]}`
+    : ` colorVariant="${playgroundColorVariant}"`;
+  const playgroundCode = `<BorderBeam size="${playgroundSize}"${playgroundColorProp}${playgroundStrength < 100 ? ` strength={${playgroundStrength / 100}}` : ''}>
   <Card>Content</Card>
 </BorderBeam>`;
 
@@ -631,6 +645,43 @@ export default function App() {
                   </button>
                 ))}
               </div>
+              {isCustomColor && (
+                <div className="custom-colors-row">
+                  {playgroundCustomColors.map((color, i) => (
+                    <input
+                      key={i}
+                      type="color"
+                      className="custom-color-swatch"
+                      value={color}
+                      aria-label={`Custom color ${i + 1}`}
+                      onChange={(e) =>
+                        setPlaygroundCustomColors((prev) =>
+                          prev.map((c, j) => (j === i ? e.target.value : c))
+                        )
+                      }
+                    />
+                  ))}
+                  <button
+                    type="button"
+                    className="tab-btn custom-color-btn"
+                    onClick={() => setPlaygroundCustomColors((prev) => prev.slice(0, -1))}
+                    disabled={playgroundCustomColors.length <= 1}
+                    aria-label="Remove last color"
+                  >
+                    −
+                  </button>
+                  <button
+                    type="button"
+                    className="tab-btn custom-color-btn"
+                    onClick={() => setPlaygroundCustomColors((prev) => [...prev, '#ffffff'])}
+                    disabled={playgroundCustomColors.length >= 5}
+                    aria-label="Add color"
+                  >
+                    +
+                  </button>
+                  <span className="custom-colors-hint">ordered · first is most prominent</span>
+                </div>
+              )}
             </div>
 
             <div className="control-group control-group--strength">
@@ -662,7 +713,8 @@ export default function App() {
             <BorderBeam
               className={playgroundSize === 'pulse-outside' ? 'beam-host--pulse-outside-tuned' : undefined}
               size={playgroundSize}
-              colorVariant={playgroundColorVariant}
+              colorVariant={playgroundVariant}
+              colors={isCustomColor ? playgroundCustomColors : undefined}
               theme={theme}
               active={playgroundActive}
               strength={playgroundStrength / 100}

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1349,6 +1349,64 @@ html[data-theme='light'] .control-label {
   outline-offset: 2px;
 }
 
+/* Custom-palette editor: ordered color wells + add/remove, shown when the
+   "Custom" color option is active. */
+.custom-colors-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.custom-color-swatch {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+}
+
+.custom-color-swatch::-webkit-color-swatch-wrapper {
+  padding: 5px;
+}
+
+.custom-color-swatch::-webkit-color-swatch {
+  border: none;
+  border-radius: 5px;
+}
+
+.custom-color-swatch::-moz-color-swatch {
+  border: none;
+  border-radius: 5px;
+}
+
+.custom-color-btn {
+  width: 36px;
+  padding: 0;
+  font-size: 16px;
+}
+
+.custom-color-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.custom-colors-hint {
+  font-size: 12px;
+  color: rgba(251, 251, 251, 0.4);
+  white-space: nowrap;
+}
+
+html[data-theme='light'] .custom-color-swatch {
+  background: #ebebeb;
+}
+
+html[data-theme='light'] .custom-colors-hint {
+  color: #999;
+}
+
 /* Light-mode playground buttons. Scoped under .playground-controls so the
    Rotate/Pulse family tabs (with their sliding pill) keep their own styling. */
 html[data-theme='light'] .playground-controls .tab-btn {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "border-beam",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Animated border beam effect for React",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/ports/ios/BorderBeamDemo/Sources/ContentView.swift
+++ b/ports/ios/BorderBeamDemo/Sources/ContentView.swift
@@ -4,11 +4,36 @@ import BorderBeamKit
 /// Showcase for BorderBeamKit, mirroring the web demo at beam.jakubantalik.com:
 /// every beam type rendered live, with the color variant and theme switchable
 /// so all 40 combinations can be eyeballed on device.
+/// Demo-local palette selection: the four library variants plus a "Custom"
+/// entry showcasing the `colors:` parameter (the library keeps custom colors
+/// out of `BeamColorVariant` on purpose — they're an ordered list, not a
+/// preset).
+private enum PaletteChoice: String, CaseIterable {
+    case colorful, mono, ocean, sunset, custom
+}
+
 struct ContentView: View {
-    @State private var variant: BeamColorVariant = .colorful
+    @State private var palette: PaletteChoice = .colorful
     @State private var theme: BeamTheme = .dark
     @State private var active = true
     @State private var tuned = false
+    /// Editable palette behind the "Custom" selection, seeded with the same
+    /// triad the web verification page uses (#e63946, #457b9d, #2a9d8f).
+    @State private var customColors: [Color] = [
+        Color(red: 230 / 255, green: 57 / 255, blue: 70 / 255),
+        Color(red: 69 / 255, green: 123 / 255, blue: 157 / 255),
+        Color(red: 42 / 255, green: 157 / 255, blue: 143 / 255),
+    ]
+
+    /// The library variant behind the current selection; "Custom" passes
+    /// `colors:` instead, which takes precedence over any variant.
+    private var variant: BeamColorVariant {
+        BeamColorVariant(rawValue: palette.rawValue) ?? .colorful
+    }
+
+    private var colorsForBeam: [Color]? {
+        palette == .custom ? customColors : nil
+    }
 
     private var isDark: Bool { theme != .light }
 
@@ -26,6 +51,7 @@ struct ContentView: View {
                         BeamSample(
                             size: size,
                             variant: variant,
+                            colors: colorsForBeam,
                             theme: theme,
                             active: active,
                             isDark: isDark,
@@ -63,9 +89,9 @@ struct ContentView: View {
 
     private var controls: some View {
         VStack(spacing: 14) {
-            Picker("Color", selection: $variant) {
-                ForEach(BeamColorVariant.allCases, id: \.self) { v in
-                    Text(v.rawValue.capitalized).tag(v)
+            Picker("Color", selection: $palette) {
+                ForEach(PaletteChoice.allCases, id: \.self) { p in
+                    Text(p.rawValue.capitalized).tag(p)
                 }
             }
             .pickerStyle(.segmented)
@@ -87,6 +113,39 @@ struct ContentView: View {
                 .font(.system(size: 13))
                 .foregroundStyle(secondary)
                 .tint(.blue)
+
+            // Live editor for the custom palette: ordered color wells (the
+            // first is the most prominent; extra colors cycle through the
+            // gradient stops), capped at 5 to keep the row readable.
+            if palette == .custom {
+                HStack(spacing: 12) {
+                    ForEach(customColors.indices, id: \.self) { i in
+                        ColorPicker("", selection: $customColors[i], supportsOpacity: false)
+                            .labelsHidden()
+                            .frame(width: 32)
+                    }
+
+                    Button {
+                        customColors.removeLast()
+                    } label: {
+                        Image(systemName: "minus.circle")
+                    }
+                    .disabled(customColors.count <= 1)
+
+                    Button {
+                        customColors.append(.white)
+                    } label: {
+                        Image(systemName: "plus.circle")
+                    }
+                    .disabled(customColors.count >= 5)
+
+                    Spacer()
+
+                    Text("ordered · first is most prominent")
+                        .font(.system(size: 12))
+                        .foregroundStyle(secondary)
+                }
+            }
         }
     }
 }
@@ -96,6 +155,7 @@ struct ContentView: View {
 private struct BeamSample: View {
     let size: BeamSize
     let variant: BeamColorVariant
+    let colors: [Color]?
     let theme: BeamTheme
     let active: Bool
     let isDark: Bool
@@ -116,6 +176,7 @@ private struct BeamSample: View {
             BorderBeam(
                 size: size,
                 colorVariant: variant,
+                colors: colors,
                 theme: theme,
                 active: active,
                 borderRadius: radius,

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamCustomPalette.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamCustomPalette.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Palette set built from user-supplied custom colors (web `colors` prop
+/// parity, see styles.ts `buildCustomPalettes`).
+///
+/// Every family keeps ALL of the hand-tuned geometry (positions, sizes,
+/// per-stop alphas) of the spec's reference variant and only substitutes the
+/// colors, cycling through the user's list in order (stop i gets
+/// colors[i % n], so the first color is the most prominent). Alpha in the
+/// inputs is ignored — every layer manages its own opacity. Custom palettes
+/// always render with static colors so brand hues stay exact.
+struct BeamCustomPalette {
+    /// md ring + pulse family perimeter blobs (9).
+    let border: [BeamSpec.GradientBlob]
+    /// sm (button) variant stroke / inner blobs (8 each).
+    let smallBorder: [BeamSpec.GradientBlob]
+    let smallInner: [BeamSpec.GradientBlob]
+    /// Traveling line blobs per theme (9 each).
+    let line: [String: [BeamSpec.LineBlob]]
+    let lineInner: [BeamSpec.LineBlob]
+    /// Pre-baked line bloom gradients per theme, recolored via the spec's
+    /// `customColors.lineBloomColorMap` (trailing glow dot / ambient / shadow
+    /// gradients keep their built-in colors).
+    let lineBloom: [String: [BeamSpec.BloomGradient]]
+
+    /// Fails on an empty list, so the caller falls back to the preset
+    /// `colorVariant` (web parity). Colors resolve against `environment` so
+    /// dynamic/adaptive colors (`.primary`, asset-catalog colors) follow the
+    /// view's actual appearance — rebuild the palette when it changes (the
+    /// component does this by deriving it in `body`).
+    init?(colors: [Color], environment: EnvironmentValues) {
+        guard !colors.isEmpty else { return nil }
+        let css = colors.map { Self.cssString(for: $0, in: environment) }
+
+        let spec = BeamSpec.shared
+        let refKey = spec.customColors.referenceVariant
+        let at = { (i: Int) in css[i % css.count] }
+
+        border = spec.palettes.border[refKey]!.border.enumerated().map { i, blob in
+            BeamSpec.GradientBlob(color: at(i), pos: blob.pos, size: blob.size)
+        }
+
+        let small = spec.palettes.small[refKey]!
+        smallBorder = small.border.enumerated().map { i, blob in
+            BeamSpec.GradientBlob(color: Self.recolor(blob.color, with: at(i)), pos: blob.pos, size: blob.size)
+        }
+        smallInner = small.inner.enumerated().map { i, blob in
+            BeamSpec.GradientBlob(color: Self.recolor(blob.color, with: at(i)), pos: blob.pos, size: blob.size)
+        }
+
+        line = spec.palettes.line[refKey]!.mapValues { blobs in
+            blobs.enumerated().map { i, blob in
+                BeamSpec.LineBlob(
+                    color: at(i),
+                    sizeW: blob.sizeW, sizeH: blob.sizeH,
+                    offsetX: blob.offsetX, offsetY: blob.offsetY
+                )
+            }
+        }
+
+        lineInner = spec.palettes.lineInner[refKey]!.enumerated().map { i, blob in
+            BeamSpec.LineBlob(
+                color: Self.recolor(blob.color, with: at(i)),
+                sizeW: blob.sizeW, sizeH: blob.sizeH,
+                offsetX: blob.offsetX, offsetY: blob.offsetY
+            )
+        }
+
+        let bloomMap = spec.customColors.lineBloomColorMap
+        lineBloom = spec.line.bloomGradients[refKey]!.mapValues { gradients in
+            gradients.enumerated().map { i, g in
+                guard i < bloomMap.count, let c = BeamRGBA(css: at(bloomMap[i])) else { return g }
+                return BeamSpec.BloomGradient(
+                    xPct: g.xPct, yOffPx: g.yOffPx, w: g.w, h: g.h,
+                    stops: g.stops.map {
+                        BeamSpec.BloomStop(r: c.r * 255, g: c.g * 255, b: c.b * 255, a: $0.a, pos: $0.pos)
+                    }
+                )
+            }
+        }
+    }
+
+    /// Resolves a SwiftUI `Color` to a solid `rgb()` spec string; alpha is
+    /// dropped (the beam layers manage their own opacity). Wide-gamut (P3)
+    /// components are clamped per channel to the sRGB cube.
+    private static func cssString(for color: Color, in environment: EnvironmentValues) -> String {
+        let resolved = color.resolve(in: environment)
+        let to255 = { (v: Float) in Int((min(max(v, 0), 1) * 255).rounded()) }
+        return "rgb(\(to255(resolved.red)), \(to255(resolved.green)), \(to255(resolved.blue)))"
+    }
+
+    /// styles.ts `recolor`: swaps a reference color's rgb for a custom one,
+    /// keeping the reference alpha (rgba refs stay rgba; rgb refs stay solid).
+    private static func recolor(_ ref: String, with rgb: String) -> String {
+        guard ref.hasPrefix("rgba"), let a = BeamRGBA(css: ref)?.a else { return rgb }
+        return rgb
+            .replacingOccurrences(of: "rgb(", with: "rgba(")
+            .replacingOccurrences(of: ")", with: ", \(a))")
+    }
+}

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamSpec.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BeamSpec.swift
@@ -245,6 +245,17 @@ struct BeamSpec: Decodable {
         let rotate: Double
     }
 
+    /// Derivation rules for user-supplied custom colors (see
+    /// ``BeamCustomPalette``): which preset variant donates the geometry and
+    /// per-stop alphas, and how the pre-baked line bloom gradients recolor.
+    struct CustomColors: Decodable {
+        let referenceVariant: String
+        let forcesStaticColors: Bool
+        /// line.bloomGradients recolor map: template gradient index → user
+        /// color index. Gradients beyond the map keep their built-in colors.
+        let lineBloomColorMap: [Int]
+    }
+
     struct Defaults: Decodable {
         let duration: DurationDefaults
         let hueRange: Double
@@ -264,6 +275,7 @@ struct BeamSpec: Decodable {
     let sizePresets: [String: SizeConfig]
     let sizeThemePresets: [String: [String: ThemeColors]]
     let palettes: Palettes
+    let customColors: CustomColors
     let rotate: Rotate
     let line: Line
     let pulse: Pulse

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BorderBeam.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/BorderBeam.swift
@@ -8,6 +8,8 @@ import SwiftUI
 /// }
 /// // or
 /// Card().borderBeam(.md, colorVariant: .ocean)
+/// // or with custom brand colors (ordered; overrides colorVariant)
+/// Card().borderBeam(.md, colors: [.purple, .pink])
 /// ```
 ///
 /// Rendering matches the web version layer-for-layer: an inner glow layer, a
@@ -30,7 +32,14 @@ public struct BorderBeam<Content: View>: View {
     private let onActivate: (() -> Void)?
     private let onDeactivate: (() -> Void)?
     private let content: Content
+    /// Custom colors from the `colors:` parameter, resolved in `body` against
+    /// the live environment (so adaptive colors track appearance changes).
+    private let colors: [Color]?
 
+    /// Full environment capture for `Color.resolve(in:)` — dynamic colors
+    /// (`.primary`, asset-catalog colors) must resolve against the view's
+    /// actual environment, not whatever traits are current at init.
+    @Environment(\.self) private var environmentValues
     @Environment(\.colorScheme) private var colorScheme
     /// Web parity: only the pulse family honors reduced motion.
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -41,9 +50,15 @@ public struct BorderBeam<Content: View>: View {
     /// that never delivers `onAppear` (e.g. `ImageRenderer`) still draws.
     @State private var mounted: Bool
 
+    /// - Parameter colors: Custom colors for the beam, in display order.
+    ///   Takes precedence over `colorVariant` and always renders with static
+    ///   colors so brand hues stay exact (web `colors` prop parity). Colors
+    ///   cycle in order through the palette's gradient stops — the first
+    ///   color is the most prominent. Opacity components are ignored.
     public init(
         size: BeamSize = .md,
         colorVariant: BeamColorVariant = .colorful,
+        colors: [Color]? = nil,
         theme: BeamTheme = .dark,
         staticColors: Bool = false,
         duration: Double? = nil,
@@ -60,6 +75,7 @@ public struct BorderBeam<Content: View>: View {
     ) {
         self.size = size
         self.colorVariant = colorVariant
+        self.colors = colors
         self.theme = theme
         self.staticColors = staticColors
         self.duration = duration
@@ -77,18 +93,23 @@ public struct BorderBeam<Content: View>: View {
     }
 
     public var body: some View {
+        // Resolved per body evaluation so adaptive colors track the live
+        // environment; nil when the parameter is absent (preset applies).
+        let customPalette = colors.flatMap {
+            BeamCustomPalette(colors: $0, environment: environmentValues)
+        }
         content
             .background {
                 // pulse-outside core + bloom glow behind the content
                 // (web z-index -1; the wrapped child must be opaque).
                 if mounted, size == .pulseOutside {
-                    PulseBeamLayers(config: pulseConfig, fade: fade, part: .glow)
+                    PulseBeamLayers(config: pulseConfig(customPalette), fade: fade, part: .glow)
                         .allowsHitTesting(false)
                 }
             }
             .overlay {
                 if mounted {
-                    beamOverlay.allowsHitTesting(false)
+                    beamOverlay(customPalette).allowsHitTesting(false)
                 }
             }
             .onAppear { if active { setActive(true) } }
@@ -123,16 +144,16 @@ public struct BorderBeam<Content: View>: View {
     // MARK: - Overlay dispatch
 
     @ViewBuilder
-    private var beamOverlay: some View {
+    private func beamOverlay(_ customPalette: BeamCustomPalette?) -> some View {
         switch size {
         case .sm, .md:
-            RotateBeamLayers(config: rotateConfig, fade: fade)
+            RotateBeamLayers(config: rotateConfig(customPalette), fade: fade)
         case .line:
-            LineBeamLayers(config: lineConfig, fade: fade)
+            LineBeamLayers(config: lineConfig(customPalette), fade: fade)
         case .pulseInner:
-            PulseBeamLayers(config: pulseConfig, fade: fade, part: .all)
+            PulseBeamLayers(config: pulseConfig(customPalette), fade: fade, part: .all)
         case .pulseOutside:
-            PulseBeamLayers(config: pulseConfig, fade: fade, part: .stroke)
+            PulseBeamLayers(config: pulseConfig(customPalette), fade: fade, part: .stroke)
         }
     }
 
@@ -144,47 +165,56 @@ public struct BorderBeam<Content: View>: View {
         }
     }
 
-    private var finalStaticColors: Bool {
-        colorVariant == .mono ? true : staticColors
+    /// Custom colors render through the 'colorful' code paths (no mono
+    /// opacity halving) and always pin the hue so brand colors stay exact.
+    private func effectiveVariant(_ customPalette: BeamCustomPalette?) -> BeamColorVariant {
+        customPalette != nil ? .colorful : colorVariant
     }
 
-    private var rotateConfig: RotateBeamConfig {
+    private func finalStaticColors(_ customPalette: BeamCustomPalette?) -> Bool {
+        if customPalette != nil { return true }
+        return colorVariant == .mono ? true : staticColors
+    }
+
+    private func rotateConfig(_ customPalette: BeamCustomPalette?) -> RotateBeamConfig {
         RotateBeamConfig(
             size: size,
-            variant: colorVariant,
+            variant: effectiveVariant(customPalette),
             theme: resolvedTheme,
-            staticColors: finalStaticColors,
+            staticColors: finalStaticColors(customPalette),
             duration: duration ?? BeamSpec.shared.defaults.duration.rotate,
             borderRadius: borderRadius,
             brightness: brightness,
             saturation: saturation,
             hueRange: hueRange,
-            strength: min(max(strength, 0), 1)
+            strength: min(max(strength, 0), 1),
+            customPalette: customPalette
         )
     }
 
-    private var lineConfig: LineBeamConfig {
+    private func lineConfig(_ customPalette: BeamCustomPalette?) -> LineBeamConfig {
         let spec = BeamSpec.shared
         return LineBeamConfig(
-            variant: colorVariant,
+            variant: effectiveVariant(customPalette),
             theme: resolvedTheme,
-            staticColors: finalStaticColors,
+            staticColors: finalStaticColors(customPalette),
             duration: duration ?? spec.defaults.duration.line,
             borderRadius: borderRadius,
             brightness: brightness,
             saturation: saturation,
             // The line family caps the hue range at 13° (web parity).
             hueRange: min(hueRange, spec.defaults.lineHueRangeCap),
-            strength: min(max(strength, 0), 1)
+            strength: min(max(strength, 0), 1),
+            customPalette: customPalette
         )
     }
 
-    private var pulseConfig: PulseBeamConfig {
+    private func pulseConfig(_ customPalette: BeamCustomPalette?) -> PulseBeamConfig {
         PulseBeamConfig(
             size: size,
-            variant: colorVariant,
+            variant: effectiveVariant(customPalette),
             theme: resolvedTheme,
-            staticColors: finalStaticColors,
+            staticColors: finalStaticColors(customPalette),
             duration: duration ?? BeamSpec.shared.defaults.duration.pulse,
             borderRadius: borderRadius,
             brightness: brightness,
@@ -192,7 +222,8 @@ public struct BorderBeam<Content: View>: View {
             strength: min(max(strength, 0), 1),
             // Web parity: only the pulse family honors reduced motion.
             reduceMotion: reduceMotion,
-            tuning: tuning
+            tuning: tuning,
+            customPalette: customPalette
         )
     }
 }
@@ -204,6 +235,7 @@ public extension View {
     func borderBeam(
         _ size: BeamSize = .md,
         colorVariant: BeamColorVariant = .colorful,
+        colors: [Color]? = nil,
         theme: BeamTheme = .dark,
         staticColors: Bool = false,
         duration: Double? = nil,
@@ -220,6 +252,7 @@ public extension View {
         BorderBeam(
             size: size,
             colorVariant: colorVariant,
+            colors: colors,
             theme: theme,
             staticColors: staticColors,
             duration: duration,

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/LineBeamLayers.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/LineBeamLayers.swift
@@ -11,6 +11,9 @@ struct LineBeamConfig {
     let saturation: Double?
     let hueRange: Double // already capped at 13 by BorderBeam
     let strength: Double
+    /// Recolored palettes from the `colors:` parameter; replaces the
+    /// `variant` preset tables wholesale when present.
+    let customPalette: BeamCustomPalette?
 
     let spec = BeamSpec.shared
 
@@ -54,12 +57,19 @@ struct LineBeamLayers: View {
             : -bloomRange + 2 * bloomRange * PulseDriver.pingPong(t / spec.defaults.lineBloomHueShiftPeriod)
         // Web parity: with staticColors the line layers carry no filter (the
         // brightness/saturate live only in the hue-shift keyframes); mono's
-        // bloom keeps just its 6px blur, applied below.
+        // bloom keeps just its 6px blur, applied below. Custom palettes are
+        // the exception: they render "colorful with the hue pinned", i.e. the
+        // tuned brightness/saturate as a static filter.
         let identity: [Float] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
-        let cm = config.staticColors ? identity : BeamColorMatrix.composed(
+        let staticCM = config.customPalette != nil
+            ? BeamColorMatrix.composed(
+                hueDegrees: 0, brightness: config.finalBrightness, saturation: config.finalSaturation
+            )
+            : identity
+        let cm = config.staticColors ? staticCM : BeamColorMatrix.composed(
             hueDegrees: hue, brightness: config.finalBrightness, saturation: config.finalSaturation
         )
-        let bloomCM = config.staticColors ? identity : BeamColorMatrix.composed(
+        let bloomCM = config.staticColors ? staticCM : BeamColorMatrix.composed(
             hueDegrees: bloomHue, brightness: config.finalBrightness, saturation: config.finalSaturation
         )
 
@@ -82,9 +92,12 @@ struct LineBeamLayers: View {
         ]
 
         // Web parity: the animated bloom filter includes blur(8px); mono with
-        // static colors gets base blur(6px); other static variants none.
+        // static colors gets base blur(6px); other static variants none —
+        // except custom palettes, whose static bloom keeps the full 8px blur
+        // (unblurred, the thin spikes paint as harsh bars).
         let bloomBlur: Double = config.staticColors
-            ? (config.variant == .mono ? spec.line.monoBloomExtraBlurPx : 0)
+            ? (config.variant == .mono ? spec.line.monoBloomExtraBlurPx
+                : config.customPalette != nil ? spec.line.bloomBlurPx : 0)
             : spec.line.bloomBlurPx
 
         ZStack {
@@ -126,7 +139,7 @@ struct LineBeamLayers: View {
                 rx: wh.w * v.w, ry: wh.h * v.h, cx: bx, cy: height + wh.yOffset, stops: stops
             )
         }
-        for e in spec.palettes.line[config.variant.rawValue]![config.theme]! {
+        for e in config.customPalette?.line[config.theme] ?? spec.palettes.line[config.variant.rawValue]![config.theme]! {
             guard let c = BeamRGBA(css: e.color) else { continue }
             blobs += BlobEncoder.simple(
                 rx: e.sizeW * v.w, ry: e.sizeH * v.h,
@@ -138,7 +151,7 @@ struct LineBeamLayers: View {
 
     private func innerBlobs(v: BeamAnimation.LineFrameValues, bx: Double, height: Double) -> [Float] {
         var blobs: [Float] = []
-        for e in config.spec.palettes.lineInner[config.variant.rawValue]! {
+        for e in config.customPalette?.lineInner ?? config.spec.palettes.lineInner[config.variant.rawValue]! {
             guard let c = BeamRGBA(css: e.color) else { continue }
             blobs += BlobEncoder.simple(
                 rx: e.sizeW * v.w, ry: e.sizeH * v.h,
@@ -150,7 +163,8 @@ struct LineBeamLayers: View {
 
     private func bloomBlobs(v: BeamAnimation.LineFrameValues, bx: Double, width: Double, height: Double) -> [Float] {
         var blobs: [Float] = []
-        let grads = config.spec.line.bloomGradients[config.variant.rawValue]![config.theme]!
+        let grads = config.customPalette?.lineBloom[config.theme]
+            ?? config.spec.line.bloomGradients[config.variant.rawValue]![config.theme]!
         for g in grads {
             let cx = g.xPct.map { $0 / 100 * width } ?? bx
             blobs += BlobEncoder.stops(

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/PulseBeamLayers.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/PulseBeamLayers.swift
@@ -13,6 +13,9 @@ struct PulseBeamConfig {
     let strength: Double
     let reduceMotion: Bool
     let tuning: BeamTuning
+    /// Recolored palettes from the `colors:` parameter; replaces the
+    /// `variant` preset tables wholesale when present.
+    let customPalette: BeamCustomPalette?
 
     let spec = BeamSpec.shared
 
@@ -93,7 +96,7 @@ struct PulseBeamLayers: View {
 
     private func ringDefs() -> [PulseBlobDef] {
         let spec = config.spec
-        let palette = spec.palettes.border[config.variant.rawValue]!.border
+        let palette = config.customPalette?.border ?? spec.palettes.border[config.variant.rawValue]!.border
         return palette.enumerated().map { i, blob in
             let c = BeamRGBA(css: blob.color) ?? .clear
             let pos = parsePercentPair(blob.pos)
@@ -108,7 +111,7 @@ struct PulseBeamLayers: View {
     }
 
     private func tableDefs(_ table: [BeamSpec.PulseGradientEntry]) -> [PulseBlobDef] {
-        let palette = config.spec.palettes.border[config.variant.rawValue]!.border
+        let palette = config.customPalette?.border ?? config.spec.palettes.border[config.variant.rawValue]!.border
         return table.map { e in
             let src = palette[e.ci]
             let c = BeamRGBA(css: src.color) ?? .clear

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/Resources/beam-spec.json
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/Resources/beam-spec.json
@@ -2,9 +2,9 @@
   "specVersion": "1.0.0",
   "sourceLibrary": {
     "name": "border-beam",
-    "version": "1.3.0"
+    "version": "1.5.0"
   },
-  "generated": "2026-07-27",
+  "generated": "2026-07-28",
   "reference": "Web demo at https://beam.jakubantalik.com is the visual ground truth.",
   "enums": {
     "sizes": [
@@ -1731,6 +1731,19 @@
         }
       }
     }
+  },
+  "customColors": {
+    "referenceVariant": "colorful",
+    "forcesStaticColors": true,
+    "lineBloomColorMap": [
+      0,
+      1,
+      0,
+      1,
+      2,
+      3,
+      4
+    ]
   },
   "rotate": {
     "whiteGradientStops": {

--- a/ports/ios/BorderBeamKit/Sources/BorderBeamKit/RotateBeamLayers.swift
+++ b/ports/ios/BorderBeamKit/Sources/BorderBeamKit/RotateBeamLayers.swift
@@ -14,6 +14,9 @@ struct RotateBeamConfig {
     let saturation: Double?
     let hueRange: Double
     let strength: Double
+    /// Recolored palettes from the `colors:` parameter; replaces the
+    /// `variant` preset tables wholesale when present.
+    let customPalette: BeamCustomPalette?
 
     let spec = BeamSpec.shared
 
@@ -56,9 +59,9 @@ struct RotateBeamConfig {
     var strokeBlobs: [Float] {
         switch size {
         case .sm:
-            return blobFloats(spec.palettes.small[variant.rawValue]!.border)
+            return blobFloats(customPalette?.smallBorder ?? spec.palettes.small[variant.rawValue]!.border)
         default:
-            return blobFloats(spec.palettes.border[variant.rawValue]!.border)
+            return blobFloats(customPalette?.border ?? spec.palettes.border[variant.rawValue]!.border)
         }
     }
 
@@ -67,12 +70,12 @@ struct RotateBeamConfig {
     var innerBlobs: [Float] {
         switch size {
         case .sm:
-            return blobFloats(spec.palettes.small[variant.rawValue]!.inner)
+            return blobFloats(customPalette?.smallInner ?? spec.palettes.small[variant.rawValue]!.inner)
         default:
             let d = spec.rotate.innerGradientDerivation
             let alpha = variant == .mono ? d.monoAlpha : d.alpha
             return blobFloats(
-                spec.palettes.border[variant.rawValue]!.border,
+                customPalette?.border ?? spec.palettes.border[variant.rawValue]!.border,
                 sizeScale: d.sizeScale,
                 alphaOverride: alpha
             )
@@ -129,9 +132,17 @@ struct RotateBeamLayers: View {
         let hue = config.hueShiftDegrees(at: t)
         // Web parity: with staticColors the CSS stroke/inner layers have NO
         // filter at all — brightness/saturate exist only inside the hue-shift
-        // keyframes. Only the bloom keeps its (static) filter.
+        // keyframes. Only the bloom keeps its (static) filter. Custom
+        // palettes are the exception: they render "colorful with the hue
+        // pinned", i.e. the tuned brightness/saturate as a static filter.
         let filterMatrix: [Float] = config.staticColors
-            ? [1, 0, 0, 0, 1, 0, 0, 0, 1]
+            ? (config.customPalette != nil
+                ? BeamColorMatrix.composed(
+                    hueDegrees: 0,
+                    brightness: config.finalBrightness,
+                    saturation: config.finalSaturation
+                )
+                : [1, 0, 0, 0, 1, 0, 0, 0, 1])
             : BeamColorMatrix.composed(
                 hueDegrees: hue,
                 brightness: config.finalBrightness,

--- a/ports/ios/BorderBeamKit/Tests/BorderBeamKitTests/BeamSpecTests.swift
+++ b/ports/ios/BorderBeamKit/Tests/BorderBeamKitTests/BeamSpecTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import BorderBeamKit
 
@@ -12,6 +13,121 @@ import Testing
         #expect(spec.pulse.inner["dark"]?.oscillators.count == 17)
         #expect(spec.sizeThemePresets["md"]?["dark"] != nil)
         #expect(spec.sizeThemePresets["pulse-outside"]?["light"] != nil)
+        #expect(spec.customColors.referenceVariant == "colorful")
+        #expect(spec.customColors.lineBloomColorMap == [0, 1, 0, 1, 2, 3, 4])
+    }
+
+    /// Five distinct single-channel colors make every cycling index and every
+    /// bloom-map entry byte-distinguishable — a swapped or collapsed mapping
+    /// in ANY family fails these assertions.
+    static let cycleColors: [(Double, Double, Double)] = [
+        (10, 0, 0), (0, 20, 0), (0, 0, 30), (40, 40, 0), (0, 50, 50),
+    ]
+
+    static func makeCyclePalette() -> BeamCustomPalette? {
+        BeamCustomPalette(
+            colors: cycleColors.map { Color(red: $0.0 / 255, green: $0.1 / 255, blue: $0.2 / 255) },
+            environment: EnvironmentValues()
+        )
+    }
+
+    /// Expected solid color string for cycle index i.
+    static func cycleCSS(_ i: Int) -> String {
+        let c = cycleColors[i % cycleColors.count]
+        return "rgb(\(Int(c.0)), \(Int(c.1)), \(Int(c.2)))"
+    }
+
+    @Test func customPaletteRecolorsReferenceGeometry() throws {
+        let palette = try #require(Self.makeCyclePalette())
+        let spec = BeamSpec.shared
+
+        // Border: colors cycle in order, geometry verbatim from the reference.
+        let ref = spec.palettes.border["colorful"]!.border
+        #expect(palette.border.count == ref.count)
+        for (i, blob) in palette.border.enumerated() {
+            #expect(blob.color == Self.cycleCSS(i))
+            #expect(blob.pos == ref[i].pos)
+            #expect(blob.size == ref[i].size)
+        }
+
+        // Small border/inner: cycling + per-stop alpha retention (inner refs
+        // are rgba; the custom color keeps the reference alpha exactly).
+        let refSmall = spec.palettes.small["colorful"]!
+        for (i, blob) in palette.smallBorder.enumerated() {
+            #expect(BeamRGBA(css: blob.color) == BeamRGBA(css: Self.cycleCSS(i)))
+        }
+        for (i, blob) in palette.smallInner.enumerated() {
+            let got = try #require(BeamRGBA(css: blob.color))
+            let refAlpha = try #require(BeamRGBA(css: refSmall.inner[i].color)?.a)
+            let want = try #require(BeamRGBA(css: Self.cycleCSS(i)))
+            #expect(got.r == want.r && got.g == want.g && got.b == want.b)
+            #expect(abs(got.a - refAlpha) < 1e-9)
+        }
+
+        // Line (both themes): cycling over each theme's own geometry.
+        for theme in ["dark", "light"] {
+            let refLine = spec.palettes.line["colorful"]![theme]!
+            let gotLine = try #require(palette.line[theme])
+            #expect(gotLine.count == refLine.count)
+            for (i, blob) in gotLine.enumerated() {
+                #expect(blob.color == Self.cycleCSS(i))
+                #expect(blob.sizeW == refLine[i].sizeW && blob.offsetX == refLine[i].offsetX)
+            }
+        }
+
+        // Line inner: cycling + alpha retention.
+        let refLineInner = spec.palettes.lineInner["colorful"]!
+        for (i, blob) in palette.lineInner.enumerated() {
+            let got = try #require(BeamRGBA(css: blob.color))
+            let want = try #require(BeamRGBA(css: Self.cycleCSS(i)))
+            let refAlpha = try #require(BeamRGBA(css: refLineInner[i].color)?.a)
+            #expect(got.r == want.r && got.g == want.g && got.b == want.b)
+            #expect(abs(got.a - refAlpha) < 1e-9)
+        }
+    }
+
+    /// The full lineBloomColorMap contract, both themes: every mapped
+    /// gradient's stops carry the mapped cycle color with the reference
+    /// alphas; every trailing gradient (glow dot, ambient, light shadow) is
+    /// untouched. Would fail for a swapped, collapsed, or truncated map.
+    @Test func customPaletteAppliesFullLineBloomMap() throws {
+        let palette = try #require(Self.makeCyclePalette())
+        let spec = BeamSpec.shared
+        let map = spec.customColors.lineBloomColorMap
+
+        for theme in ["dark", "light"] {
+            let ref = spec.line.bloomGradients["colorful"]![theme]!
+            let got = try #require(palette.lineBloom[theme])
+            #expect(got.count == ref.count)
+            for (i, gradient) in got.enumerated() {
+                if i < map.count {
+                    let want = try #require(BeamRGBA(css: Self.cycleCSS(map[i])))
+                    for (s, stop) in gradient.stops.enumerated() {
+                        #expect(stop.r == want.r * 255 && stop.g == want.g * 255 && stop.b == want.b * 255)
+                        #expect(stop.a == ref[i].stops[s].a)
+                        #expect(stop.pos == ref[i].stops[s].pos)
+                    }
+                } else {
+                    for (s, stop) in gradient.stops.enumerated() {
+                        let r = ref[i].stops[s]
+                        #expect(stop.r == r.r && stop.g == r.g && stop.b == r.b && stop.a == r.a)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test func customPaletteSingleColorAndEmptyList() {
+        // A single color paints every stop (monochrome brand beam). The
+        // mid-tone channel values also pin sRGB (gamma) resolution — a
+        // linear-space mistake in cssString would shift 230 to ~201.
+        let single = BeamCustomPalette(
+            colors: [Color(red: 230 / 255, green: 57 / 255, blue: 70 / 255)],
+            environment: EnvironmentValues()
+        )
+        #expect(single?.border.allSatisfy { $0.color == "rgb(230, 57, 70)" } == true)
+        // An empty list fails so the preset variant applies.
+        #expect(BeamCustomPalette(colors: [], environment: EnvironmentValues()) == nil)
     }
 
     @Test func colorParsing() throws {

--- a/ports/ios/BorderBeamKit/Tests/BorderBeamKitTests/SnapshotTests.swift
+++ b/ports/ios/BorderBeamKit/Tests/BorderBeamKitTests/SnapshotTests.swift
@@ -46,12 +46,14 @@ struct SnapshotTests {
     /// A card mimicking the web demo's surface, wrapped in the beam.
     @ViewBuilder
     static func card(
-        size: BeamSize, variant: BeamColorVariant, theme: BeamTheme, active: Bool = true
+        size: BeamSize, variant: BeamColorVariant, theme: BeamTheme, active: Bool = true,
+        colors: [Color]? = nil
     ) -> some View {
         let isDark = theme != .light
         BorderBeam(
             size: size,
             colorVariant: variant,
+            colors: colors,
             theme: theme,
             active: active,
             borderRadius: cardRadius
@@ -69,14 +71,15 @@ struct SnapshotTests {
     /// Renders one combination onto a demo-like background and returns the PNG.
     /// `active: false` yields the beam-off reference used for blank detection.
     static func render(
-        size: BeamSize, variant: BeamColorVariant, theme: BeamTheme, active: Bool = true
+        size: BeamSize, variant: BeamColorVariant, theme: BeamTheme, active: Bool = true,
+        colors: [Color]? = nil
     ) -> Data? {
         let isDark = theme != .light
         // Padding leaves room for pulse-outside's halo, which spills outward.
         let pad: CGFloat = 60
         let scene = ZStack {
             (isDark ? Color(white: 0.027) : Color(white: 1.0))
-            card(size: size, variant: variant, theme: theme, active: active)
+            card(size: size, variant: variant, theme: theme, active: active, colors: colors)
         }
         .frame(
             width: cardSize.width + pad * 2,
@@ -128,6 +131,36 @@ struct SnapshotTests {
         }
         #expect(written == BeamSize.allCases.count * BeamColorVariant.allCases.count * 2)
         #expect(blank.isEmpty, "these combinations rendered no beam: \(blank)")
+    }
+
+    /// Same brand palette the web verification page uses (#e63946, #457b9d,
+    /// #2a9d8f) — every size × theme must paint a beam from custom colors.
+    @Test func rendersCustomColors() throws {
+        let dir = Self.outputDir
+        let brand: [Color] = [
+            Color(red: 230 / 255, green: 57 / 255, blue: 70 / 255),
+            Color(red: 69 / 255, green: 123 / 255, blue: 157 / 255),
+            Color(red: 42 / 255, green: 157 / 255, blue: 143 / 255),
+        ]
+        var blank: [String] = []
+
+        for size in BeamSize.allCases {
+            for theme: BeamTheme in [.dark, .light] {
+                let name = "\(size.rawValue)_custom_\(theme.rawValue).png"
+                let png = try #require(
+                    Self.render(size: size, variant: .colorful, theme: theme, colors: brand),
+                    "render returned nil for \(name)"
+                )
+                try png.write(to: dir.appendingPathComponent(name))
+                let off = try #require(
+                    Self.render(size: size, variant: .colorful, theme: theme, active: false, colors: brand),
+                    "beam-off render returned nil for \(name)"
+                )
+                if !Self.differs(png, off) { blank.append(name) }
+            }
+        }
+
+        #expect(blank.isEmpty, "these custom-color combinations rendered no beam: \(blank)")
     }
 
     /// True when two renders differ measurably — i.e. the beam painted

--- a/scripts/extract-spec.ts
+++ b/scripts/extract-spec.ts
@@ -298,6 +298,22 @@ const spec = {
     lineBloom: lineBloomColors,
   },
 
+  // User-supplied custom colors (web `colors` prop / iOS `colors:` parameter):
+  // every palette family keeps the reference variant's geometry and per-stop
+  // alphas and only swaps in the user colors, cycling in order (stop i gets
+  // colors[i % n]; rgba references keep their alpha). See styles.ts
+  // buildCustomPalettes + BeamCustomPalette.swift — keep both in sync.
+  customColors: {
+    referenceVariant: 'colorful',
+    // Custom palettes always render static (like mono) so brand hues stay exact.
+    forcesStaticColors: true,
+    // Recolor map for line.bloomGradients: template gradient index → user color
+    // index (sc1=spike.primary→0, sc2=spike.secondary→1, spikes[0..4]→0..4).
+    // Gradients beyond the map (traveling glow dot, ambient, light-theme
+    // shadow) keep their built-in colors.
+    lineBloomColorMap: [0, 1, 0, 1, 2, 3, 4],
+  },
+
   rotate: {
     whiteGradientStops: rotateWhiteGradientStops,
     bloomGradientStops: rotateBloomGradientStops,

--- a/spec/beam-spec.json
+++ b/spec/beam-spec.json
@@ -2,9 +2,9 @@
   "specVersion": "1.0.0",
   "sourceLibrary": {
     "name": "border-beam",
-    "version": "1.3.0"
+    "version": "1.5.0"
   },
-  "generated": "2026-07-27",
+  "generated": "2026-07-28",
   "reference": "Web demo at https://beam.jakubantalik.com is the visual ground truth.",
   "enums": {
     "sizes": [
@@ -1731,6 +1731,19 @@
         }
       }
     }
+  },
+  "customColors": {
+    "referenceVariant": "colorful",
+    "forcesStaticColors": true,
+    "lineBloomColorMap": [
+      0,
+      1,
+      0,
+      1,
+      2,
+      3,
+      4
+    ]
   },
   "rotate": {
     "whiteGradientStops": {

--- a/src/BorderBeam.tsx
+++ b/src/BorderBeam.tsx
@@ -12,7 +12,14 @@ import {
   type MutableRefObject,
 } from 'react';
 import type { BorderBeamProps, BorderBeamTheme } from './types';
-import { sizePresets, sizeThemePresets, generateBeamCSS, getPulseDriverConfig } from './styles';
+import {
+  sizePresets,
+  sizeThemePresets,
+  generateBeamCSS,
+  getPulseDriverConfig,
+  normalizeCustomColors,
+  buildCustomPalettes,
+} from './styles';
 import { registerPulseInstance } from './pulseDriver';
 
 function useSystemTheme(): 'dark' | 'light' {
@@ -56,6 +63,7 @@ export const BorderBeam = forwardRef<HTMLDivElement, BorderBeamProps>(
       children,
       size = 'md',
       colorVariant = 'colorful',
+      colors,
       theme = 'dark',
       staticColors = false,
       duration,
@@ -200,12 +208,27 @@ export const BorderBeam = forwardRef<HTMLDivElement, BorderBeamProps>(
 
     const isPulse = size === 'pulse-inner' || size === 'pulse-outside';
 
+    // Build the custom palette set once per distinct color list (the
+    // serialized key keeps inline array literals from rebuilding the palettes
+    // every render, and unlike join() cannot collide across different
+    // arrays). Falls back to the preset variant when no entry parses.
+    const colorsKey = colors ? JSON.stringify(colors) : undefined;
+    const customPalette = useMemo(() => {
+      if (!colors || colors.length === 0) return null;
+      const normalized = normalizeCustomColors(colors);
+      return normalized ? buildCustomPalettes(normalized) : null;
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [colorsKey]);
+
     const finalBorderRadius = customBorderRadius ?? detectedRadius ?? sizeConfig.borderRadius;
     const finalDuration = duration ?? (size === 'line' ? 3.1 : isPulse ? 2.3 : 1.96);
     const finalSaturation = saturation ?? themeConfig.saturation;
     const finalBrightness = brightnessProp ?? themeConfig.brightness ?? 1.3;
     const finalHueRange = size === 'line' ? Math.min(hueRange, 13) : hueRange;
-    const finalStaticColors = colorVariant === 'mono' ? true : staticColors;
+    // Custom colors render through the 'colorful' code paths (no mono opacity
+    // halving) and always pin the hue so brand colors stay exact.
+    const effectiveVariant = customPalette ? 'colorful' : colorVariant;
+    const finalStaticColors = customPalette ? true : colorVariant === 'mono' ? true : staticColors;
 
     const cssStyles = useMemo(
       () =>
@@ -219,13 +242,14 @@ export const BorderBeam = forwardRef<HTMLDivElement, BorderBeamProps>(
           bloomOpacity: themeConfig.bloomOpacity,
           innerShadow: themeConfig.innerShadow,
           size,
-          colorVariant,
+          colorVariant: effectiveVariant,
           staticColors: finalStaticColors,
           brightness: finalBrightness,
           saturation: finalSaturation,
           hueRange: finalHueRange,
           theme: resolvedTheme,
           hairlineOpacity: themeConfig.hairlineOpacity,
+          customPalette,
         }),
       [
         id,
@@ -238,12 +262,13 @@ export const BorderBeam = forwardRef<HTMLDivElement, BorderBeamProps>(
         themeConfig.innerShadow,
         themeConfig.hairlineOpacity,
         size,
-        colorVariant,
+        effectiveVariant,
         finalStaticColors,
         finalBrightness,
         finalSaturation,
         finalHueRange,
         resolvedTheme,
+        customPalette,
       ]
     );
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -295,29 +295,29 @@ export const smallColorPalettes = {
   },
 };
 
-function getSmallColorGradients(colorVariant: BorderBeamColorVariant): string {
-  const palette = smallColorPalettes[colorVariant];
+function getSmallColorGradients(colorVariant: BorderBeamColorVariant, custom?: CustomPaletteSet | null): string {
+  const palette = custom?.small ?? smallColorPalettes[colorVariant];
   return palette.border
     .map(c => `radial-gradient(ellipse ${c.size} at ${c.pos}, ${c.color}, transparent)`)
     .join(',\n    ');
 }
 
-function getSmallInnerGradients(colorVariant: BorderBeamColorVariant): string {
-  const palette = smallColorPalettes[colorVariant];
+function getSmallInnerGradients(colorVariant: BorderBeamColorVariant, custom?: CustomPaletteSet | null): string {
+  const palette = custom?.small ?? smallColorPalettes[colorVariant];
   return palette.inner
     .map(c => `radial-gradient(ellipse ${c.size} at ${c.pos}, ${c.color}, transparent)`)
     .join(',\n    ');
 }
 
-function getColorGradients(colorVariant: BorderBeamColorVariant): string {
-  const palette = colorPalettes[colorVariant];
+function getColorGradients(colorVariant: BorderBeamColorVariant, custom?: CustomPaletteSet | null): string {
+  const palette = custom?.border ?? colorPalettes[colorVariant];
   return palette.border
     .map(c => `radial-gradient(ellipse ${c.size} at ${c.pos}, ${c.color}, transparent)`)
     .join(',\n    ');
 }
 
-function getInnerGradients(colorVariant: BorderBeamColorVariant): string {
-  const palette = colorPalettes[colorVariant];
+function getInnerGradients(colorVariant: BorderBeamColorVariant, custom?: CustomPaletteSet | null): string {
+  const palette = custom?.border ?? colorPalettes[colorVariant];
   // Mono variant gets 50% lower opacity
   const baseOpacity = colorVariant === 'mono' ? 0.225 : 0.45;
   return palette.border
@@ -332,8 +332,8 @@ function getInnerGradients(colorVariant: BorderBeamColorVariant): string {
     .join(',\n    ');
 }
 
-function getSpikeColors(colorVariant: BorderBeamColorVariant, isDark: boolean) {
-  const palette = colorPalettes[colorVariant];
+function getSpikeColors(colorVariant: BorderBeamColorVariant, isDark: boolean, custom?: CustomPaletteSet | null) {
+  const palette = custom?.border ?? colorPalettes[colorVariant];
   return isDark ? palette.spike : palette.spikeLt;
 }
 
@@ -436,8 +436,13 @@ export const lineColorPalettes = {
   },
 };
 
-function getLineColorGradients(colorVariant: BorderBeamColorVariant, isDark: boolean, id: string): string {
-  const palette = lineColorPalettes[colorVariant][isDark ? 'dark' : 'light'];
+function getLineColorGradients(
+  colorVariant: BorderBeamColorVariant,
+  isDark: boolean,
+  id: string,
+  custom?: CustomPaletteSet | null
+): string {
+  const palette = (custom?.line ?? lineColorPalettes[colorVariant])[isDark ? 'dark' : 'light'];
   return palette
     .map(c => {
       const offsetXStr = c.offsetX === 0 ? '' : (c.offsetX > 0 ? ` + ${c.offsetX}px` : ` - ${Math.abs(c.offsetX)}px`);
@@ -495,8 +500,12 @@ export const lineInnerGradientData = {
   ],
 };
 
-function getLineInnerGradients(colorVariant: BorderBeamColorVariant, id: string): string {
-  const data = lineInnerGradientData[colorVariant];
+function getLineInnerGradients(
+  colorVariant: BorderBeamColorVariant,
+  id: string,
+  custom?: CustomPaletteSet | null
+): string {
+  const data = custom?.lineInner ?? lineInnerGradientData[colorVariant];
   return data
     .map(c => {
       const offsetXStr = c.offsetX === 0 ? '' : (c.offsetX > 0 ? ` + ${c.offsetX}px` : ` - ${Math.abs(c.offsetX)}px`);
@@ -605,9 +614,137 @@ function attenuateSpike(color: string, factor: number): string {
   return color;
 }
 
-function getLineBloomGradients(colorVariant: BorderBeamColorVariant, isDark: boolean, id: string): string {
-  const spikeColors = getSpikeColors(colorVariant, isDark);
-  const bloomData = lineBloomColors[colorVariant][isDark ? 'dark' : 'light'];
+/* ──────────────────────────────────────────────────────────────────────────
+ * Custom colors — user-supplied brand palettes (the `colors` prop).
+ *
+ * A custom palette keeps ALL of the hand-tuned geometry (positions, sizes,
+ * per-stop alphas) of the 'colorful' reference variant and only substitutes
+ * the colors, cycling through the user's list in order (stop i gets
+ * colors[i % n], so the first color is the most prominent). Alpha in the
+ * inputs is ignored — every layer manages its own opacity. Custom palettes
+ * always render with static colors so brand hues stay exact.
+ *
+ * The iOS port rebuilds the same palettes from the spec's reference tables
+ * (BeamCustomPalette.swift + the spec's `customColors` section) — keep the
+ * derivation rules in sync.
+ * ──────────────────────────────────────────────────────────────────────────*/
+
+/**
+ * A full recolored palette set covering all five palette families. Shapes
+ * match the preset tables so the CSS generators consume either transparently.
+ */
+export interface CustomPaletteSet {
+  border: (typeof colorPalettes)['colorful'];
+  small: (typeof smallColorPalettes)['colorful'];
+  line: (typeof lineColorPalettes)['colorful'];
+  lineInner: (typeof lineInnerGradientData)['colorful'];
+  lineBloom: (typeof lineBloomColors)['colorful'];
+}
+
+/**
+ * Parses one user-supplied CSS color (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`,
+ * `rgb()`, `rgba()` — commas or spaces, number or percentage channels) into a
+ * solid `rgb(r, g, b)` string. Returns null for anything else (named colors,
+ * hsl, malformed input, …) so the component can fall back to the preset.
+ */
+function normalizeCustomColor(input: string): string | null {
+  const s = input.trim();
+  const hex = s.match(/^#([0-9a-fA-F]{3,8})$/)?.[1];
+  if (hex && hex.length !== 5 && hex.length !== 7) {
+    const wide = hex.length <= 4 ? [...hex].map(ch => ch + ch).join('') : hex;
+    const r = parseInt(wide.slice(0, 2), 16);
+    const g = parseInt(wide.slice(2, 4), 16);
+    const b = parseInt(wide.slice(4, 6), 16);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  // Anchored, with strict numerals ("1.2.3" or an unclosed paren must fall
+  // back to the preset, not leak NaN/garbage into the generated CSS). The
+  // optional alpha token is validated but ignored — layers manage opacity.
+  const m = s.match(
+    /^rgba?\(\s*(-?\d*\.?\d+%?)\s*[,\s]\s*(-?\d*\.?\d+%?)\s*[,\s]\s*(-?\d*\.?\d+%?)\s*(?:[,/]\s*-?\d*\.?\d+%?\s*)?\)$/
+  );
+  if (!m) return null;
+  const channel = (raw: string): number => {
+    const value = parseFloat(raw);
+    const scaled = raw.endsWith('%') ? (value / 100) * 255 : value;
+    return Math.round(Math.min(255, Math.max(0, scaled)));
+  };
+  return `rgb(${channel(m[1])}, ${channel(m[2])}, ${channel(m[3])})`;
+}
+
+/**
+ * Normalizes the `colors` prop, dropping entries that fail to parse. Returns
+ * null when nothing usable remains so the component falls back to the preset
+ * `colorVariant`.
+ */
+export function normalizeCustomColors(colors: readonly string[]): string[] | null {
+  const parsed = colors.map(normalizeCustomColor).filter((c): c is string => c !== null);
+  return parsed.length > 0 ? parsed : null;
+}
+
+/** Alpha of an `rgba()` reference color, or null when it is a solid `rgb()`. */
+function refAlpha(color: string): number | null {
+  const m = color.match(/^rgba\([^)]*,\s*([\d.]+)\s*\)$/);
+  return m ? parseFloat(m[1]) : null;
+}
+
+/** Swaps a reference color's rgb for a custom one, keeping the reference alpha. */
+function recolor(ref: string, rgb: string): string {
+  const a = refAlpha(ref);
+  return a === null ? rgb : withAlpha(rgb, a);
+}
+
+/**
+ * Builds the full palette set from normalized custom colors by recoloring the
+ * 'colorful' reference tables in user order.
+ */
+export function buildCustomPalettes(colors: string[]): CustomPaletteSet {
+  const at = (i: number) => colors[i % colors.length];
+  const ref = colorPalettes.colorful;
+  const refSmall = smallColorPalettes.colorful;
+  const refLine = lineColorPalettes.colorful;
+  const refBloom = lineBloomColors.colorful;
+  const recolorPair = (s: { color1: string; color2: string }, i: number) => ({
+    color1: recolor(s.color1, at(i)),
+    color2: recolor(s.color2, at(i)),
+  });
+  return {
+    border: {
+      border: ref.border.map((c, i) => ({ ...c, color: at(i) })),
+      // The first two colors lead the line bloom's traveling spikes.
+      spike: {
+        primary: recolor(ref.spike.primary, at(0)),
+        secondary: recolor(ref.spike.secondary, at(1)),
+      },
+      spikeLt: {
+        primary: recolor(ref.spikeLt.primary, at(0)),
+        secondary: recolor(ref.spikeLt.secondary, at(1)),
+      },
+    },
+    small: {
+      border: refSmall.border.map((c, i) => ({ ...c, color: recolor(c.color, at(i)) })),
+      inner: refSmall.inner.map((c, i) => ({ ...c, color: recolor(c.color, at(i)) })),
+    },
+    line: {
+      dark: refLine.dark.map((c, i) => ({ ...c, color: at(i) })),
+      light: refLine.light.map((c, i) => ({ ...c, color: at(i) })),
+    },
+    lineInner: lineInnerGradientData.colorful.map((c, i) => ({ ...c, color: recolor(c.color, at(i)) })),
+    lineBloom: {
+      dark: { spikes: refBloom.dark.spikes.map(recolorPair) },
+      light: { spikes: refBloom.light.spikes.map(recolorPair) },
+    },
+  };
+}
+
+function getLineBloomGradients(
+  colorVariant: BorderBeamColorVariant,
+  isDark: boolean,
+  id: string,
+  custom?: CustomPaletteSet | null
+): string {
+  const spikeColors = getSpikeColors(colorVariant, isDark, custom);
+  const bloomData = (custom?.lineBloom ?? lineBloomColors[colorVariant])[isDark ? 'dark' : 'light'];
   const isMono = colorVariant === 'mono';
 
   // Mono uses uniform gray so thin spikes at full opacity look like harsh bars.
@@ -776,8 +913,8 @@ function pulseGrad(
 
 // The 9-gradient perimeter ring (Card 4 ::after / Card 5 stroke share this) —
 // positions + sizes come straight from the palette, region/quad from PULSE_RING_MAP.
-function pulseRingGradients(variant: BorderBeamColorVariant, id: string): string {
-  return colorPalettes[variant].border
+function pulseRingGradients(variant: BorderBeamColorVariant, id: string, custom?: CustomPaletteSet | null): string {
+  return (custom?.border ?? colorPalettes[variant]).border
     .map((c, i) => {
       const { region, quad } = PULSE_RING_MAP[i];
       const [x, y] = c.pos.split(' ');
@@ -788,8 +925,13 @@ function pulseRingGradients(variant: BorderBeamColorVariant, id: string): string
 }
 
 // Card 4 inner-perimeter gradients (smaller sizes) plus the bright corner accents.
-function pulseInnerGradients(variant: BorderBeamColorVariant, id: string, isDark: boolean): string {
-  const palette = colorPalettes[variant].border;
+function pulseInnerGradients(
+  variant: BorderBeamColorVariant,
+  id: string,
+  isDark: boolean,
+  custom?: CustomPaletteSet | null
+): string {
+  const palette = (custom?.border ?? colorPalettes[variant]).border;
   const grads = palette.map((c, i) => {
     const { region, quad } = PULSE_RING_MAP[i];
     const [x, y] = c.pos.split(' ');
@@ -815,9 +957,10 @@ function pulseInnerGradients(variant: BorderBeamColorVariant, id: string, isDark
 function pulseTableGradients(
   table: PulseGradientDef[],
   variant: BorderBeamColorVariant,
-  id: string
+  id: string,
+  custom?: CustomPaletteSet | null
 ): string {
-  const palette = colorPalettes[variant].border;
+  const palette = (custom?.border ?? colorPalettes[variant]).border;
   return table
     .map(e => {
       const c = palette[e.ci];
@@ -836,9 +979,10 @@ function pulseTableGradients(
 function pulseTableGradientsStatic(
   table: PulseGradientDef[],
   variant: BorderBeamColorVariant,
-  frozenAlpha: number
+  frozenAlpha: number,
+  custom?: CustomPaletteSet | null
 ): string {
-  const palette = colorPalettes[variant].border;
+  const palette = (custom?.border ?? colorPalettes[variant]).border;
   const a = +frozenAlpha.toFixed(3);
   return table
     .map(e => {
@@ -1023,6 +1167,11 @@ interface GenerateStylesOptions {
   theme: 'dark' | 'light';
   /** Opacity of the 1px hairline outline (pulse-outside only). Falls back to 0. */
   hairlineOpacity?: number;
+  /**
+   * Recolored palette set built from the `colors` prop; replaces the
+   * `colorVariant` preset tables wholesale when present.
+   */
+  customPalette?: CustomPaletteSet | null;
 }
 
 /**
@@ -1066,17 +1215,24 @@ function generateSmallVariantCSS(options: GenerateStylesOptions): string {
     saturation,
     hueRange,
     theme,
+    customPalette,
   } = options;
 
   const innerRadius = Math.max(0, borderRadius - borderWidth);
-  
+
   const monoOpacityMultiplier = colorVariant === 'mono' ? 0.5 : 1.0;
   const finalStrokeOpacity = strokeOpacity * monoOpacityMultiplier;
   const finalInnerOpacity = innerOpacity * monoOpacityMultiplier;
   const finalBloomOpacity = bloomOpacity * monoOpacityMultiplier;
   
-  const hueShiftAnimation = staticColors 
-    ? '' 
+  // Custom palettes render "colorful with the hue pinned": the tuned
+  // brightness/saturate normally live inside the hue-shift keyframes' filter,
+  // so a static custom palette applies them as a static filter instead.
+  // Preset static renders (mono / staticColors) keep their filter-less look.
+  const hueShiftAnimation = staticColors
+    ? customPalette
+      ? `filter: brightness(${brightness.toFixed(2)}) saturate(${saturation.toFixed(2)});`
+      : ''
     : `animation: beam-hue-shift-${id} 12s ease-in-out infinite;`;
   
   const hueShiftKeyframes = staticColors ? '' : `
@@ -1114,8 +1270,8 @@ function generateSmallVariantCSS(options: GenerateStylesOptions): string {
         transparent 78%, transparent 100%
       )`;
 
-  const colorGradients = getSmallColorGradients(colorVariant);
-  const innerGradients = getSmallInnerGradients(colorVariant);
+  const colorGradients = getSmallColorGradients(colorVariant, customPalette);
+  const innerGradients = getSmallInnerGradients(colorVariant, customPalette);
 
   const bloomGradient = isDark
     ? `conic-gradient(
@@ -1305,18 +1461,25 @@ function generateBorderVariantCSS(options: GenerateStylesOptions): string {
     saturation,
     hueRange,
     theme,
+    customPalette,
   } = options;
 
   const innerRadius = Math.max(0, borderRadius - borderWidth);
-  
+
   // Mono variant gets 50% lower opacity
   const monoOpacityMultiplier = colorVariant === 'mono' ? 0.5 : 1.0;
   const finalStrokeOpacity = strokeOpacity * monoOpacityMultiplier;
   const finalInnerOpacity = innerOpacity * monoOpacityMultiplier;
   const finalBloomOpacity = bloomOpacity * monoOpacityMultiplier;
   
-  const hueShiftAnimation = staticColors 
-    ? '' 
+  // Custom palettes render "colorful with the hue pinned": the tuned
+  // brightness/saturate normally live inside the hue-shift keyframes' filter,
+  // so a static custom palette applies them as a static filter instead.
+  // Preset static renders (mono / staticColors) keep their filter-less look.
+  const hueShiftAnimation = staticColors
+    ? customPalette
+      ? `filter: brightness(${brightness.toFixed(2)}) saturate(${saturation.toFixed(2)});`
+      : ''
     : `animation: beam-hue-shift-${id} 12s ease-in-out infinite;`;
   
   const hueShiftKeyframes = staticColors ? '' : `
@@ -1354,8 +1517,8 @@ function generateBorderVariantCSS(options: GenerateStylesOptions): string {
         transparent 78%, transparent 100%
       )`;
 
-  const colorGradients = getColorGradients(colorVariant);
-  const innerGradients = getInnerGradients(colorVariant);
+  const colorGradients = getColorGradients(colorVariant, customPalette);
+  const innerGradients = getInnerGradients(colorVariant, customPalette);
 
   const bloomGradient = isDark
     ? `conic-gradient(
@@ -1549,6 +1712,7 @@ function generatePulseInnerVariantCSS(options: GenerateStylesOptions): string {
     id, borderRadius, borderWidth, duration,
     strokeOpacity, innerOpacity, bloomOpacity,
     colorVariant, staticColors, brightness, saturation, hueRange, theme,
+    customPalette,
   } = options;
 
   const isDark = theme === 'dark';
@@ -1578,10 +1742,10 @@ function generatePulseInnerVariantCSS(options: GenerateStylesOptions): string {
     ? `filter: blur(${bloomBlur}px) brightness(${b}) saturate(${s});`
     : `filter: blur(${bloomBlur}px) hue-rotate(calc(var(--beam-hue-base, 0deg) + var(--beam-hue-${id}))) brightness(${b}) saturate(${s});`;
 
-  const ringGradients = pulseRingGradients(colorVariant, id);
-  const innerGradients = pulseInnerGradients(colorVariant, id, isDark);
+  const ringGradients = pulseRingGradients(colorVariant, id, customPalette);
+  const innerGradients = pulseInnerGradients(colorVariant, id, isDark, customPalette);
   // Frozen at the breathing time-average (midpoint of the [1-op, 1] opacity range).
-  const bloomGradients = pulseTableGradientsStatic(PULSE_INNER_BLOOM, colorVariant, 1 - op * 0.5);
+  const bloomGradients = pulseTableGradientsStatic(PULSE_INNER_BLOOM, colorVariant, 1 - op * 0.5, customPalette);
 
   return `
 ${pulsePropertyRegs(id)}
@@ -1703,6 +1867,7 @@ function generatePulseOuterVariantCSS(options: GenerateStylesOptions): string {
     strokeOpacity, innerOpacity, bloomOpacity,
     colorVariant, staticColors, brightness, saturation, hueRange, theme,
     hairlineOpacity = 0,
+    customPalette,
   } = options;
 
   const isDark = theme === 'dark';
@@ -1753,10 +1918,10 @@ function generatePulseOuterVariantCSS(options: GenerateStylesOptions): string {
     ? `filter: blur(var(--beam-bloom-blur, ${bloomBlur}px)) ${glowBright};`
     : `filter: blur(var(--beam-bloom-blur, ${bloomBlur}px)) hue-rotate(calc(var(--beam-hue-base, 0deg) + var(--beam-hue-${id}))) ${glowBright};`;
 
-  const strokeGradients = pulseTableGradients(PULSE_OUTER_CORE, colorVariant, id);
-  const coreGradients = pulseTableGradients(PULSE_OUTER_CORE, colorVariant, id);
+  const strokeGradients = pulseTableGradients(PULSE_OUTER_CORE, colorVariant, id, customPalette);
+  const coreGradients = pulseTableGradients(PULSE_OUTER_CORE, colorVariant, id, customPalette);
   // Frozen at the breathing time-average (midpoint of the [1-op, 1] opacity range).
-  const bloomGradients = pulseTableGradientsStatic(PULSE_OUTER_BLOOM, colorVariant, 1 - op * 0.5);
+  const bloomGradients = pulseTableGradientsStatic(PULSE_OUTER_BLOOM, colorVariant, 1 - op * 0.5, customPalette);
   // Paint a static hairline in the SAME masked ring as the stroke glow so their
   // position and anti-aliasing always match exactly.
   const strokeBackground = hairlineOpacity > 0
@@ -1890,21 +2055,34 @@ function generateLineVariantCSS(options: GenerateStylesOptions): string {
     saturation,
     hueRange,
     theme,
+    customPalette,
   } = options;
 
   const innerRadius = Math.max(0, borderRadius - borderWidth);
   const isDark = theme === 'dark';
-  
+
   const finalStrokeOpacity = strokeOpacity;
   const finalInnerOpacity = innerOpacity;
   const finalBloomOpacity = bloomOpacity;
   
-  const hueShiftAnimation = staticColors 
-    ? '' 
+  // Custom palettes render "colorful with the hue pinned": the tuned
+  // brightness/saturate normally live inside the hue-shift keyframes' filter,
+  // so a static custom palette applies them as a static filter instead.
+  // Preset static renders (mono / staticColors) keep their filter-less look.
+  const hueShiftAnimation = staticColors
+    ? customPalette
+      ? `filter: brightness(${brightness.toFixed(2)}) saturate(${saturation.toFixed(2)});`
+      : ''
     : `animation: beam-hue-shift-${id} 12s ease-in-out infinite;`;
 
+  // Same "hue pinned" rule for the bloom: its blur(8px) lives only inside the
+  // bloom keyframes' filter, so a static custom palette must re-apply it or
+  // the thin spike gradients paint as harsh unblurred bars (the artifact the
+  // mono attenuation below works around).
   const hueShiftBloomAnimation = staticColors
-    ? ''
+    ? customPalette
+      ? `filter: blur(8px) brightness(${brightness.toFixed(2)}) saturate(${saturation.toFixed(2)});`
+      : ''
     : `animation: beam-hue-shift-bloom-${id} 8s ease-in-out infinite;`;
   
   const hueShiftKeyframes = staticColors ? '' : `
@@ -1934,10 +2112,10 @@ function generateLineVariantCSS(options: GenerateStylesOptions): string {
         transparent 70%
       )`;
 
-  const colorGradients = getLineColorGradients(colorVariant, isDark, id);
-  const innerGradients = getLineInnerGradients(colorVariant, id);
+  const colorGradients = getLineColorGradients(colorVariant, isDark, id, customPalette);
+  const innerGradients = getLineInnerGradients(colorVariant, id, customPalette);
 
-  const bloomGradients = getLineBloomGradients(colorVariant, isDark, id);
+  const bloomGradients = getLineBloomGradients(colorVariant, isDark, id, customPalette);
   const monoBloomBlur = colorVariant === 'mono' ? 'filter: blur(6px);' : '';
 
   return `

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,18 @@ export interface BorderBeamProps extends Omit<HTMLAttributes<HTMLDivElement>, 'c
   colorVariant?: BorderBeamColorVariant;
 
   /**
+   * Custom colors for the beam, in display order. Accepts hex (`#rgb`,
+   * `#rgba`, `#rrggbb`, `#rrggbbaa`) and `rgb()` / `rgba()` with number or
+   * percentage channels. Takes precedence over `colorVariant` and always
+   * renders with static colors so brand hues stay exact (like 'mono').
+   * Colors cycle in order through the palette's gradient stops — the first
+   * color is the most prominent. Alpha components are ignored; the beam
+   * layers manage their own opacity. Entries that fail to parse are
+   * skipped; when nothing parses, `colorVariant` applies.
+   */
+  colors?: string[];
+
+  /**
    * Theme mode - adapts beam/glow colors for dark or light backgrounds
    * 'auto' detects system preference via prefers-color-scheme
    * @default 'dark'


### PR DESCRIPTION
Closes #4.

## What this adds

An ordered list of custom colors on both platforms:

```tsx
<BorderBeam colors={['#e63946', '#457b9d', '#2a9d8f']}>…</BorderBeam>
```

```swift
Card().borderBeam(.md, colors: [.purple, .pink])
```

- Colors cycle **in order** through the palette's gradient stops — the first color is the most prominent; a single color gives a monochrome brand beam.
- All hand-tuned geometry (positions, sizes, per-stop alphas) of the `colorful` reference palette is preserved — only the colors are swapped, across all five palette families (border ring, small, line, line-inner, line-bloom).
- `colors` takes precedence over `colorVariant` and always renders with static hue (like `mono`) so brand colors stay exact; the tuned brightness/saturate still apply as a static filter.
- Accepts hex (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) and `rgb()`/`rgba()` with number or percentage channels; alpha is ignored (layers manage their own opacity). Entries that fail to parse are skipped; if nothing parses, `colorVariant` applies. On iOS, `[Color]` resolves against the live SwiftUI environment so adaptive colors track appearance changes.

## Cross-platform parity

The derivation contract lives in `beam-spec.json § customColors` (reference variant, forced static colors, line-bloom recolor map `[0,1,0,1,2,3,4]`), so the web (`buildCustomPalettes` in `styles.ts`) and iOS (`BeamCustomPalette.swift`) implementations recolor the same spec tables and cannot silently drift. Executing both derivations against the same input and diffing numerically produced an exact match across every family, both themes, all alphas.

## Verification

- **Presets untouched:** generated CSS byte-identical to `main` across all 80 preset combinations (5 sizes × 4 variants × 2 themes × 2 static modes).
- **Web:** typecheck + build clean; 18-assertion parser/regression suite (attack inputs incl. malformed rgb, trailing garbage, NaN-shaped numerals); rendered-browser verification of all 5 sizes × 2 themes with live-DOM assertions (brand colors present, hue-shift absent, reference alphas retained).
- **iOS:** 14/14 tests via both `swift test` and `xcodebuild test` with compiled Metal shaders; new tests pin the full line-bloom color map in both themes, cycling + alpha retention in every family, sRGB (gamma) color resolution, and a custom-color snapshot matrix.
- An adversarial review pass (three independent reviewers instructed to refute) surfaced 10 findings — parser holes, a memo-key collision, missing static filters, init-time color resolution — all fixed and re-verified.

## Demos

Both demos gained a **Custom** entry in the palette switcher with live ordered color editors (1–5 colors, add/remove): native `ColorPicker` row in the SwiftUI demo, color inputs in the web playground. The playground's generated snippet updates to the real `colors={[…]}` usage as you edit.

## Notes

- `BeamColorVariant` is intentionally left unextended (a new case would be source-breaking for `String`-raw-value + `CaseIterable` consumers); custom colors are a separate parameter on both platforms.
- Suggested follow-up: a CI fixture that re-runs the web↔iOS palette diff automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)