### PR TITLE
Render the reduced-motion frame at raw engine time

### DIFF
--- a/packages/thinking-orbs/ports/ios/ThinkingOrbsKit/Sources/ThinkingOrbsKit/ThinkingOrb.swift
+++ b/packages/thinking-orbs/ports/ios/ThinkingOrbsKit/Sources/ThinkingOrbsKit/ThinkingOrb.swift
@@ -69,7 +69,7 @@ public struct ThinkingOrb: View {
                 canvas(preset: preset, t: frozenTime)
             } else if reduceMotion || paused {
                 // one static, deterministic frame — same instant as the web
-                canvas(preset: preset, t: OrbSpec.reducedMotionT * effSpeed)
+                canvas(preset: preset, t: OrbSpec.reducedMotionT)
             } else {
                 TimelineView(.animation(paused: paused)) { timeline in
                     // One shared clock, so several orbs on screen stay in

--- a/packages/thinking-orbs/ports/ios/ThinkingOrbsKit/Tests/ThinkingOrbsKitTests/ReducedMotionParityTests.swift
+++ b/packages/thinking-orbs/ports/ios/ThinkingOrbsKit/Tests/ThinkingOrbsKitTests/ReducedMotionParityTests.swift
@@ -1,0 +1,144 @@
+// Pins the reduced-motion / paused static frame to the same instant the
+// frozen-time path renders.
+//
+// Both paths claim to render OrbSpec.reducedMotionT. The frozen-time branch
+// passes it through raw; the static branch multiplies it by effSpeed. Since
+// engine time already has preset speed folded in (spec.paint.clock), only one
+// of them can be right -- and the web reference (src/ThinkingOrb.tsx) renders
+// a bare frame(0.6), so it is the frozen-time branch.
+//
+// Rendering both through the real SwiftUI Canvas and comparing rasters means
+// this test fails on the actual painted output, not on a recomputed number.
+
+import XCTest
+import SwiftUI
+@testable import ThinkingOrbsKit
+
+@available(iOS 16.0, macOS 13.0, *)
+final class ReducedMotionParityTests: XCTestCase {
+
+    /// Rasterise a view to straight RGBA8 through a context we control, so the
+    /// comparison never depends on whatever backing format ImageRenderer picked.
+    @MainActor
+    private func raster<V: View>(_ view: V, scale: Double) -> (w: Int, h: Int, px: [UInt8])? {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = scale
+        renderer.isOpaque = false
+        guard let cg = renderer.cgImage else { return nil }
+        let w = cg.width, h = cg.height
+        var px = [UInt8](repeating: 0, count: w * h * 4)
+        let ok: Bool = px.withUnsafeMutableBytes { raw -> Bool in
+            guard let ctx = CGContext(
+                data: raw.baseAddress,
+                width: w, height: h,
+                bitsPerComponent: 8, bytesPerRow: w * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else { return false }
+            ctx.draw(cg, in: CGRect(x: 0, y: 0, width: w, height: h))
+            return true
+        }
+        return ok ? (w, h, px) : nil
+    }
+
+    @MainActor
+    private func png<V: View>(_ view: V, scale: Double) -> Data? {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = scale
+        renderer.isOpaque = false
+        #if canImport(AppKit)
+        guard let image = renderer.nsImage,
+              let tiff = image.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        return rep.representation(using: .png, properties: [:])
+        #else
+        return renderer.uiImage?.pngData()
+        #endif
+    }
+
+    /// The frozen-time branch at reducedMotionT -- the documented-correct instant.
+    private func reference(_ state: OrbState, _ size: OrbSize) -> some View {
+        ThinkingOrb(state: state, size: size, theme: .light)
+            .orbFrozenTime(OrbSpec.reducedMotionT)
+            .frame(width: size.value, height: size.value)
+    }
+
+    /// The static branch. `paused` reaches the identical line as reduceMotion,
+    /// without having to fake an accessibility environment.
+    private func subject(_ state: OrbState, _ size: OrbSize) -> some View {
+        ThinkingOrb(state: state, size: size, theme: .light, paused: true)
+            .frame(width: size.value, height: size.value)
+    }
+
+    @MainActor
+    func testStaticFrameRendersTheSameInstantAsFrozenTime() throws {
+        var mismatches: [String] = []
+        var report: [String] = []
+
+        for state in OrbState.allCases {
+            for size in OrbSize.allCases {
+                let key = "\(state.rawValue)@\(size.rawValue)"
+                guard let a = raster(reference(state, size), scale: 2),
+                      let b = raster(subject(state, size), scale: 2) else {
+                    XCTFail("render failed: \(key)"); continue
+                }
+                XCTAssertEqual(a.w, b.w); XCTAssertEqual(a.h, b.h)
+
+                var differing = 0
+                var maxDelta = 0
+                for i in stride(from: 0, to: a.px.count, by: 4) {
+                    var worst = 0
+                    for c in 0..<4 {
+                        worst = max(worst, abs(Int(a.px[i + c]) - Int(b.px[i + c])))
+                    }
+                    if worst > 1 { differing += 1 }
+                    maxDelta = max(maxDelta, worst)
+                }
+                let total = a.w * a.h
+                let pct = Double(differing) / Double(total) * 100
+                let effSpeed = resolvePreset(state, size).speed
+                report.append(String(
+                    format: "  %-14@ speed %.3f  static t=%.3f  differing %5.2f%%  maxΔ %3d",
+                    key as NSString, effSpeed,
+                    OrbSpec.reducedMotionT * effSpeed, pct, maxDelta
+                ))
+                if differing > 0 {
+                    mismatches.append(String(format: "%@ (%.2f%% of pixels, maxΔ %d)", key, pct, maxDelta))
+                }
+            }
+        }
+
+        print("reduced-motion vs frozen-time @ t=\(OrbSpec.reducedMotionT):")
+        report.forEach { print($0) }
+
+        XCTAssertTrue(
+            mismatches.isEmpty,
+            "\(mismatches.count)/18 (state × size) pairs render a different frame "
+            + "from the static path than from frozen time:\n" + mismatches.joined(separator: "\n")
+        )
+    }
+
+    /// Writes the before/after images for a bug report. Opt-in.
+    @MainActor
+    func testWriteReproImages() throws {
+        guard let outDir = ProcessInfo.processInfo.environment["ORB_REPRO_DIR"] else {
+            throw XCTSkip("set ORB_REPRO_DIR to capture")
+        }
+        let dir = URL(fileURLWithPath: outDir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        var n = 0
+        for state in OrbState.allCases {
+            for size in OrbSize.allCases where size == .px64 {
+                let key = "\(state.rawValue)-\(size.rawValue)"
+                if let d = png(reference(state, size), scale: 8) {
+                    try d.write(to: dir.appendingPathComponent("\(key)-expected.png")); n += 1
+                }
+                if let d = png(subject(state, size), scale: 8) {
+                    try d.write(to: dir.appendingPathComponent("\(key)-actual.png")); n += 1
+                }
+            }
+        }
+        print("wrote \(n) repro images to \(outDir)")
+    }
+}


### PR DESCRIPTION
`ThinkingOrbsKit` renders the reduced-motion / paused static frame at a
different instant than the web build, for every state and size.

<img width="1614" height="416" alt="swiftui-reduced-motion-bug" src="https://github.com/user-attachments/assets/a2389a05-9f2b-4067-973c-f04f5345acbe" />

<img width="840" height="486" alt="swiftui-reduced-motion-connecting" src="https://github.com/user-attachments/assets/8dde7f5e-2c3a-4ce8-90cb-f20f127e11b1" />

## The two branches disagree

`ports/ios/ThinkingOrbsKit/Sources/ThinkingOrbsKit/ThinkingOrb.swift:64-72`

```swift
if let frozenTime {
    // Raw engine time, NOT scaled by speed: the golden vectors and
    // the web parity harness both evaluate the engine at this t
    // directly, so applying the preset speed here would compare
    // two different instants and report a false mismatch.
    canvas(preset: preset, t: frozenTime)              // <- correct
} else if reduceMotion || paused {
    // one static, deterministic frame — same instant as the web
    canvas(preset: preset, t: OrbSpec.reducedMotionT * effSpeed)   // <- scaled
}
```

Same rule, two answers. The comment on the second states the intent — "same
instant as the web" — that the code then breaks.

The web reference does not scale it (`src/ThinkingOrb.tsx:90-99`):

```ts
// reduced motion → one static, deterministic frame
if (reduced) {
  frame(0.6);
  return;
}
// ... the live loop, nine lines later:
frame((performance.now() / 1000) * effSpeed);
```

`0.6` is already engine time. `spec.paint.clock` defines engine time as
`elapsedSeconds * presetSpeed * userSpeed`, which is why the live loop
multiplies on the way in and the constant must not be multiplied again.

## Measured

`paused` reaches the identical line as `reduceMotion`, so the test needs no
faked accessibility environment. Both paths render through the real SwiftUI
`Canvas` via `ImageRenderer` and the rasters are compared, so the guard fails
on painted output rather than on a recomputed number — headless, no simulator.

Before, all 18 (state × size) pairs differ:

```
  working@64    speed 1.885  static t=1.131  differing 19.57%  maxD 255
  working@20    speed 3.900  static t=2.340  differing 22.69%  maxD 255
  searching@64  speed 2.015  static t=1.209  differing 20.76%  maxD 200
  searching@20  speed 2.665  static t=1.599  differing 32.50%  maxD 210
  solving@64    speed 1.820  static t=1.092  differing 14.41%  maxD 255
  solving@20    speed 1.950  static t=1.170  differing 26.31%  maxD 255
  listening@64  speed 4.388  static t=2.633  differing 15.47%  maxD 255
  listening@20  speed 3.998  static t=2.399  differing 30.19%  maxD 255
  connecting@64 speed 3.315  static t=1.989  differing 29.93%  maxD 255
  connecting@20 speed 6.630  static t=3.978  differing 12.38%  maxD 255
  weaving@64    speed 1.625  static t=0.975  differing 16.64%  maxD 250
  weaving@20    speed 2.750  static t=1.650  differing 24.62%  maxD 252
  composing@64  speed 2.340  static t=1.404  differing 23.33%  maxD 255
  composing@20  speed 3.120  static t=1.872  differing 30.75%  maxD 255
  breathing@64  speed 3.240  static t=1.944  differing 10.41%  maxD 255
  breathing@20  speed 3.780  static t=2.268  differing 15.69%  maxD 255
  shaping@64    speed 2.405  static t=1.443  differing  4.27%  maxD 255
  shaping@20    speed 2.080  static t=1.248  differing 15.25%  maxD 161
```

No preset has speed 1.0 — they run 1.625 to 6.63 — so nothing is exempt.
`connecting@20` renders t = 3.978 where the web renders 0.6.

After removing `* effSpeed`, all 18 are byte-identical (0.00%, maxD 0), and
the existing suite is unchanged:

```
Executed 5 tests, with 2 tests skipped and 0 failures
golden: 72 cases, 70115 values within 0.0001 (spec 1.0.0)
```

Also confirmed on a device: `ThinkingOrbsDemo` on an iPhone 17 Pro simulator
with Reduce Motion enabled in Settings, one simulator and one setting, only
`ThinkingOrbsKit` rebuilt between two captures. The frozen frame moves by
5-25% of pixels per orb. The screen was verified genuinely static first — 0 of
3162132 pixels changed across 14 seconds.

## Why the existing suite missed it

`0.6` is one of the four timestamps in `spec/orbs-golden.json`, picked so this
frame is verifiable — but `OrbGoldenTests` evaluates `orbFrame` directly and
`OrbSnapshotTests` goes through `.orbFrozenTime`. Neither ever renders the
`reduceMotion || paused` branch, so it had no coverage at all.
`ReducedMotionParityTests` closes that by comparing the two paths against each
other, so it stays honest if `reducedMotionT` is ever retuned.

Severity is parity, not breakage — t = 1.989 is still a valid pose. But it is
the pose reduced-motion users see, it disagrees with every other platform, and
`paused` inherits it.
